### PR TITLE
Travis CI: sudo tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,17 @@
-sudo: true
-
 language: python
 
 matrix:
     include:
         - os: linux
-          sudo: true
           python: 3.7
           dist: xenial
         - os: linux
-          sudo: required
           python: 3.6
         - os: linux
-          sudo: required
           python: 3.5
         - os: linux
-          sudo: required
           python: 3.4
         - os: linux
-          sudo: required
           python: 2.7
         - os: osx
           language: generic


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)