### PR TITLE
fix : classnames in matrix deprecated after relabel removed

### DIFF
--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -397,7 +397,9 @@ class ConfusionMatrix():
                 temp_dict[mapping[col]] = self.table[row][col]
                 temp_dict_normalized[mapping[col]
                                      ] = self.normalized_table[row][col]
+            del self.table[row]
             self.table[mapping[row]] = temp_dict
+            del self.normalized_table[row]
             self.normalized_table[mapping[row]] = temp_dict_normalized
         self.matrix = self.table
         self.normalized_matrix = self.normalized_table


### PR DESCRIPTION
Issue #167 