### PR TITLE
TRAVIS check added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- vulture section edited
 ### Added
 - Tversky index (TI)
 - Area under the PR curve (AUPR)

--- a/Otherfiles/test.sh
+++ b/Otherfiles/test.sh
@@ -7,7 +7,7 @@
   isInTRAVIS=false
   if [ "$CI" = 'true' ] && [ "$TRAVIS" = 'true' ]
   then
-      $isInTRAVIS=true
+      isInTRAVIS=true
   fi
 
   if [ "$isInTRAVIS" = 'false' ] || { [ "$isInTRAVIS" = 'true' ] && [ "$TRAVIS_PYTHON_VERSION" = '3.6' ]; }

--- a/Otherfiles/test.sh
+++ b/Otherfiles/test.sh
@@ -2,7 +2,15 @@
   set -x
   python -m pytest Test --cov=pycm --cov-report=term
   python Otherfiles/version_check.py
-  if [ "$TRAVIS_PYTHON_VERSION" = '3.6' ]
+
+  #Check if we are in TRAVIS
+  isInTRAVIS=false
+  if [ "$CI" = 'true' ] && [ "$TRAVIS" = 'true' ]
+  then
+      $isInTRAVIS=true
+  fi
+
+  if [ "$isInTRAVIS" = 'false' ] || { [ "$isInTRAVIS" = 'true' ] && [ "$TRAVIS_PYTHON_VERSION" = '3.6' ]; }
   then
       python -m vulture pycm/ Otherfiles/ setup.py --min-confidence 65 --exclude=build,.eggs --sort-by-size
       python -m bandit -r pycm -s B311


### PR DESCRIPTION
vulture, bandit and pydocstyle checks now will take place only if we are not in TRAVIS or our TRAVIS Python version is 3.6.
