### PR TITLE
Issue #241 solved!

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,4 +10,4 @@
 
 #### Python Version
 
-#### PyCM Version (Enter pycm.__version__)
+#### PyCM Version (Use : `pycm.__version__`)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,4 +10,4 @@
 
 #### Python Version
 
-#### PyCM Version
+#### PyCM Version (Enter pycm.__version__)

--- a/Otherfiles/version_check.py
+++ b/Otherfiles/version_check.py
@@ -4,7 +4,7 @@ import os
 import sys
 import codecs
 Failed = 0
-VERSION = "2.4"
+PYCM_VERSION = "2.4"
 
 
 SETUP_ITEMS = [
@@ -24,7 +24,7 @@ DOCUMENT_ITEMS = [
     "pip install pycm=={0}",
     "pip3 install pycm=={0}"]
 HTML_ITEMS = ["Version {0}"]
-PARAMS_ITEMS = ['VERSION = "{0}"']
+PARAMS_ITEMS = ['PYCM_VERSION = "{0}"']
 FILES = {
     "setup.py": SETUP_ITEMS, "README.md": README_ITEMS, "CHANGELOG.md": CHANGELOG_ITEMS, os.path.join(
         "Document", "Document.ipynb"): DOCUMENT_ITEMS, os.path.join(
@@ -59,7 +59,7 @@ if __name__ == "__main__":
             file_content = codecs.open(
                 file_name, "r", "utf-8", 'ignore').read()
             for test_item in FILES[file_name]:
-                if file_content.find(test_item.format(VERSION)) == -1:
+                if file_content.find(test_item.format(PYCM_VERSION)) == -1:
                     print("Incorrect version tag in " + file_name)
                     Failed += 1
                     break

--- a/pycm/__init__.py
+++ b/pycm/__init__.py
@@ -7,3 +7,4 @@ from .pycm_obj import *
 from .pycm_compare import *
 from .pycm_util import *
 from .pycm_interpret import *
+__version__ = PYCM_VERSION

--- a/pycm/__main__.py
+++ b/pycm/__main__.py
@@ -20,9 +20,9 @@ if __name__ == "__main__":
             sys.exit(error_flag)
         else:
             tprint("pycm")
-            tprint("V:" + VERSION)
+            tprint("V:" + PYCM_VERSION)
             pycm_help()
     else:
         tprint("pycm")
-        tprint("V:" + VERSION)
+        tprint("V:" + PYCM_VERSION)
         pycm_help()

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -315,7 +315,7 @@ class ConfusionMatrix():
                     class_list,
                     self.recommended_list,
                     alt_link))
-            html_file.write(html_end(VERSION))
+            html_file.write(html_end(PYCM_VERSION))
             html_file.close()
             if address:
                 message = os.path.join(

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Parameters and constants."""
-VERSION = "2.4"
+PYCM_VERSION = "2.4"
 
 
 OVERVIEW = '''


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
VERSION variable turns into PYCM_VERSION for probable further issues.
__version__ attribute added to PYCM (Now you can use pycm.__version__).