### PR TITLE
predict_vector_state : first step to solve #256

### DIFF
--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -96,6 +96,7 @@ class ConfusionMatrix():
         __obj_assign_handler__(self, matrix_param)
         __class_stat_init__(self)
         __overall_stat_init__(self)
+        self.predict_vector_state = matrix_param[6]
         self.imbalance = imbalance_check(self.P)
         self.binary = binary_check(self.classes)
         self.recommended_list = statistic_recommend(self.classes, self.P)

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -282,6 +282,7 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight):
         sample_weight = sample_weight.tolist()
     classes = set(actual_vector).union(set(predict_vector))
     classes = sorted(classes)
+    predict_vector_state = predict_vector.copy()
     map_dict = {k: 0 for k in classes}
     table = {k: map_dict.copy() for k in classes}
     weight_vector = [1] * len(actual_vector)
@@ -290,9 +291,13 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight):
             weight_vector = sample_weight
     for index, item in enumerate(actual_vector):
         table[item][predict_vector[index]] += 1 * weight_vector[index]
+        if item is predict_vector[index]:
+            predict_vector_state[index] = 'T'
+        else
+            predict_vector_state[index] = 'F'
     [classes, table, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
-    return [classes, table, TP_dict, TN_dict, FP_dict, FN_dict]
+    return [classes, table, predict_vector_state, TP_dict, TN_dict, FP_dict, FN_dict]
 
 
 def imbalance_check(P):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -274,7 +274,7 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight):
     :type predict_vector : list
     :param sample_weight : sample weights list
     :type sample_weight : list
-    :return: [classes_list,table,TP,TN,FP,FN]
+    :return: [classes_list,table,TP,TN,FP,FN,predict_vector_state]
     """
     [actual_vector, predict_vector] = vector_filter(
         actual_vector, predict_vector)
@@ -292,12 +292,12 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight):
     for index, item in enumerate(actual_vector):
         table[item][predict_vector[index]] += 1 * weight_vector[index]
         if item is predict_vector[index]:
-            predict_vector_state[index] = 'T'
+            predict_vector_state[index] = 1
         else:
-            predict_vector_state[index] = 'F'
+            predict_vector_state[index] = 0
     [classes, table, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
-    return [classes, table, predict_vector_state, TP_dict, TN_dict, FP_dict, FN_dict]
+    return [classes, table, TP_dict, TN_dict, FP_dict, FN_dict, predict_vector_state]
 
 
 def imbalance_check(P):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -293,7 +293,7 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight):
         table[item][predict_vector[index]] += 1 * weight_vector[index]
         if item is predict_vector[index]:
             predict_vector_state[index] = 'T'
-        else
+        else:
             predict_vector_state[index] = 'F'
     [classes, table, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)


### PR DESCRIPTION
#### Reference Issues/PRs
#256 
#### What does this implement/fix? Explain your changes.
`predict_vector_state` added as a binary list that determine which one of the predict_vector element is predicted true using 1 and else wise using 0.

it has been added as a ConfusionMatrix class attribute and will help as a map to examining the truth of a predict (taking the TP, TN, FP, FN out).

for example if you want to know which one of the elements is predicted truly you can simply use (print TP and TN 's element's index):
```
for index in len(predict_vector):
    if predict_vector_state[index] is 1:
        print(index)
``` 
