### PR TITLE
normalized_table_calc's speed has been improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `costum_rounder` method added instead of `numpy.around`
 ### Added
 - `sparse_matrix` attribute
 - `sparse_normalized_matrix` attribute 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- `costum_rounder` method added instead of `numpy.around`
+- `custom_rounder` method added instead of `numpy.around`
 ### Added
 - `sparse_matrix` attribute
 - `sparse_normalized_matrix` attribute 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -207,7 +207,7 @@ def normalized_table_calc(classes, table):
         if div == 0:
             div = 1
         for item in classes:
-            normalized_table[key][item] = numpy.around(table[key][item] / div, 5)
+            normalized_table[key][item] = custom_rounder(table[key][item] / div, 5)
     return normalized_table
 
 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -206,23 +206,22 @@ def normalized_table_calc(classes, table):
         div = sum(table[key].values())
         if div == 0:
             div = 1
+        p = float(10**5)
         for item in classes:
             normalized_table[key][item] = custom_rounder(
-                table[key][item] / div, 5)
+                table[key][item] / div, p)
     return normalized_table
 
 
-def custom_rounder(input_number, digit):
+def custom_rounder(input_number, p):
     """
     Return round of a input number respected to the digit.
-
     :param input_number: number that should be round
     :type input_number: float
-    :param digit: number of digits that we should round number into
+    :param p: 10 powered by number of digits the wanted to be rounded to
     :type digit: int
     :return: rounded number in float
     """
-    p = float(10**digit)
     return int(input_number * p + 0.5) / p
 
 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -200,18 +200,19 @@ def normalized_table_calc(classes, table):
     :type table: dict
     :return: normalized table as dict
     """
-    normalized_table={}
+    normalized_table = {}
     for key in classes:
         normalized_table[key] = {}
         div = sum(table[key].values())
         if div == 0:
             div = 1
         for item in classes:
-            normalized_table[key][item] = custom_rounder(table[key][item] / div, 5)
+            normalized_table[key][item] = custom_rounder(
+                table[key][item] / div, 5)
     return normalized_table
 
 
-def custom_rounder(input_number,digit):
+def custom_rounder(input_number, digit):
     """
     Return round of a input number respected to the digit
 
@@ -222,7 +223,7 @@ def custom_rounder(input_number,digit):
     :return: rounded number in float
     """
     p = float(10**digit)
-    return int(input_number * p + 0.5)/p
+    return int(input_number * p + 0.5) / p
 
 
 def sparse_matrix_calc(classes, table):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -195,9 +195,9 @@ def normalized_table_calc(classes, table):
     Return normalized confusion matrix.
 
     :param classes: classes list
-    :type classes:list
+    :type classes: list
     :param table: table
-    :type table:dict
+    :type table: dict
     :return: normalized table as dict
     """
     normalized_table={}
@@ -230,9 +230,9 @@ def sparse_matrix_calc(classes, table):
     Return sparse confusion table and it's classes.
 
     :param classes: classes list
-    :type classes:list
+    :type classes: list
     :param table: table
-    :type table:dict
+    :type table: dict
     :return: a list containing 3 dicts(sparse_table, actual_classes, predict_classes)
     """
     sparse_table = {}

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -216,6 +216,7 @@ def normalized_table_calc(classes, table):
 def custom_rounder(input_number, p):
     """
     Return round of a input number respected to the digit.
+    
     :param input_number: number that should be round
     :type input_number: float
     :param p: 10 powered by number of digits the wanted to be rounded to

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -211,6 +211,20 @@ def normalized_table_calc(classes, table):
     return normalized_table
 
 
+def custom_rounder(input_number,digit):
+    """
+    Return round of a input number respected to the digit
+
+    :param input_number: number that should be round
+    :type input_number: float
+    :param digit: number of digits that we should round number into
+    :type digit: int
+    :return: rounded number in float
+    """
+    p = float(10**digit)
+    return int(input_number * p + 0.5)/p
+
+
 def sparse_matrix_calc(classes, table):
     """
     Return sparse confusion table and it's classes.

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -201,12 +201,12 @@ def normalized_table_calc(classes, table):
     :return: normalized table as dict
     """
     normalized_table = {}
+    p = float(10**5)
     for key in classes:
         normalized_table[key] = {}
         div = sum(table[key].values())
         if div == 0:
             div = 1
-        p = float(10**5)
         for item in classes:
             normalized_table[key][item] = custom_rounder(
                 table[key][item] / div, p)

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -214,7 +214,7 @@ def normalized_table_calc(classes, table):
 
 def custom_rounder(input_number, digit):
     """
-    Return round of a input number respected to the digit
+    Return round of a input number respected to the digit.
 
     :param input_number: number that should be round
     :type input_number: float

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -216,7 +216,7 @@ def normalized_table_calc(classes, table):
 def custom_rounder(input_number, p):
     """
     Return round of a input number respected to the digit.
-    
+
     :param input_number: number that should be round
     :type input_number: float
     :param p: 10 powered by number of digits the wanted to be rounded to


### PR DESCRIPTION
#### Reference Issues/PRs
#279 
#### What does this implement/fix? Explain your changes.
this pull request will fix `normalized_table_calc` speed problem due to slow performance of `numpy.around` for positive numbers comparing to recently added alternative `custom_round`.