### PR TITLE
Copy method

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -10,7 +10,6 @@
   fi
   $PYTHON_COMMAND -m pytest Test --cov=pycm --cov-report=term
   $PYTHON_COMMAND Otherfiles/version_check.py
-  $PYTHON_COMMAND -m cProfile -s cumtime pycm/pycm_profile.py
   
   if [ "$CI" = 'true' ] && [ "$TRAVIS" = 'true' ]
   then
@@ -23,4 +22,4 @@
       $PYTHON_COMMAND -m bandit -r pycm -s B311
       $PYTHON_COMMAND -m pydocstyle --match-dir=pycm
   fi
-
+  $PYTHON_COMMAND -m cProfile -s cumtime pycm/pycm_profile.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `to_array` method
+- `__copy__` method
+- `copy` method
 ### Changed
 - `average` method refactored
 ## [2.8] - 2020-07-09

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -3,6 +3,7 @@
 >>> from pycm import *
 >>> import os
 >>> import json
+>>> import copy
 >>> y_actu = [2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2]
 >>> y_pred = [0, 0, 2, 1, 0, 2, 1, 0, 2, 0, 2, 2]
 >>> y_actu_copy = [2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2]
@@ -1418,4 +1419,23 @@ array([[ 9,  3],
 >>> cm.to_array(one_vs_all=True, normalized=True, class_name=0)
 array([[0.75   , 0.25   ],
        [0.26667, 0.73333]])
+>>> cm = ConfusionMatrix([1,2,3,4],[1,2,3,3])
+>>> cm
+pycm.ConfusionMatrix(classes: [1, 2, 3, 4])
+>>> cm2 = cm.copy()
+>>> cm2
+pycm.ConfusionMatrix(classes: [1, 2, 3, 4])
+>>> cm3 = copy.copy(cm)
+>>> cm3
+pycm.ConfusionMatrix(classes: [1, 2, 3, 4])
+>>> cm == cm2
+True
+>>> cm == cm3
+True
+>>> id(cm) == id(cm2)
+False
+>>> id(cm) == id(cm3)
+False
+>>> id(cm2) == id(cm3)
+False
 """

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -627,7 +627,7 @@ class ConfusionMatrix():
         result = _class.__new__(_class)
         result.__dict__.update(self.__dict__)
         return result
-    
+
     def copy(self):
         return self.__copy__()
 

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -624,7 +624,8 @@ class ConfusionMatrix():
 
     def __copy__(self):
         """
-        Returns a copy of ConfusionMatrix.
+        Return a copy of ConfusionMatrix.
+
         :return: copy of ConfusionMatrix
         """
         _class = self.__class__
@@ -634,7 +635,8 @@ class ConfusionMatrix():
 
     def copy(self):
         """
-        Returns a copy of ConfusionMatrix.
+        Return a copy of ConfusionMatrix.
+
         :return: copy of ConfusionMatrix
         """
         return self.__copy__()

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -623,12 +623,20 @@ class ConfusionMatrix():
         return not self.__eq__(other)
 
     def __copy__(self):
+        """
+        Returns a copy of ConfusionMatrix.
+        :return: copy of ConfusionMatrix
+        """
         _class = self.__class__
         result = _class.__new__(_class)
         result.__dict__.update(self.__dict__)
         return result
 
     def copy(self):
+        """
+        Returns a copy of ConfusionMatrix.
+        :return: copy of ConfusionMatrix
+        """
         return self.__copy__()
 
     def relabel(self, mapping):

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -627,6 +627,9 @@ class ConfusionMatrix():
         result = _class.__new__(_class)
         result.__dict__.update(self.__dict__)
         return result
+    
+    def copy(self):
+        return self.__copy__()
 
     def relabel(self, mapping):
         """

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -622,6 +622,12 @@ class ConfusionMatrix():
         """
         return not self.__eq__(other)
 
+    def __copy__(self):
+        _class = self.__class__
+        result = _class.__new__(_class)
+        result.__dict__.update(self.__dict__)
+        return result
+
     def relabel(self, mapping):
         """
         Rename ConfusionMatrix classes.


### PR DESCRIPTION
#### Reference Issues/PRs
#327 
#### What does this implement/fix? Explain your changes.
In this pull request I've added:

+ `__copy__` method for making copy of confusion matrix object when using `cm_ = copy.copy(cm)`
+ `copy` method for doing that by `cm_ = cm.copy()` 

There are some tests showing identity and seperation of these copies which means any copy of matrix should be identically the same using `cm_ == cm` (which should logically be true) and stored in different positions in memory using `id(cm_) == id(cm)` (which should be logically false).