### PR TITLE
Combine method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - `combine` method
 ## [2.9] - 2020-09-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `combine` method
 ## [2.9] - 2020-09-23
 ### Added
 - `notebook_check.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `combine` method
+- `matrix_combine` function
 ## [2.9] - 2020-09-23
 ### Added
 - `notebook_check.py`

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -55,6 +55,7 @@
     "            <li><a href=\"#Relabel\">Relabel</a></li>\n",
     "            <li><a href=\"#Position\">Position</a></li>\n",
     "            <li><a href=\"#To-array\">To Array</a></li>\n",
+    "            <li><a href=\"#Combine\">Combine</a></li>\n",
     "            <li><a href=\"#Online-help\">Online Help</a></li>\n",
     "            <li><a href=\"#Parameter-recommender\">Parameter Recommender</a></li>\n",
     "            <li><a href=\"#Comapre\">Comapre</a></li>\n",
@@ -1456,6 +1457,83 @@
    "source": [
     "<ul>\n",
     "    <li><span style=\"color:red;\">Notice </span> :  new in <span style=\"color:red;\">version 2.9</span> </li>\n",
+    "</ul>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Combine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`combine` method is added in `version 3.0` in order to merge two confusion matrices. This option will be useful in mini-batch learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Predict 0       1       2       \n",
+      "Actual\n",
+      "0       6       0       0       \n",
+      "\n",
+      "1       0       2       4       \n",
+      "\n",
+      "2       4       2       6       \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "cm_combined = cm2.combine(cm3)\n",
+    "cm_combined.print_matrix()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Parameters "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. `other` : Other matrix that is going to be combined (type : `ConfusionMatrix`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "New `ConfusionMatrix`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<ul>\n",
+    "    <li><span style=\"color:red;\">Notice </span> :  new in <span style=\"color:red;\">version 3.0</span> </li>\n",
     "</ul>"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -567,6 +567,20 @@ array([[1.     , 0.     ],
        [0.22222, 0.77778]])
 ```
 
+### Combine
+`combine` method is added in `version 3.0` in order to merge two confusion matrices. This option will be useful in mini-batch learning.	
+
+```pycon
+>>> cm_combined = cm2.combine(cm3)
+>>> cm_combined.print_matrix()
+Predict      Class1       Class2       
+Actual
+Class1       2            4            
+
+Class2       0            10           
+
+```	
+
 ### Online help
 
 `online_help` function is added in `version 1.1` in order to open each statistics definition in web browser

--- a/Test/error_test.py
+++ b/Test/error_test.py
@@ -104,4 +104,8 @@ pycm.pycm_error.pycmAverageError: The weight type must be dictionary and also mu
 Traceback (most recent call last):
         ...
 pycm.pycm_error.pycmAverageError: The weight type must be dictionary and also must be specified for all of the classes.
+>>> cm.combine(1)
+Traceback (most recent call last):
+        ...
+pycm.pycm_error.pycmMatrixError: The input type is considered to be pycm.ConfusionMatrix object but it's not!
 """

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1438,4 +1438,28 @@ False
 False
 >>> id(cm2) == id(cm3)
 False
+>>> cm1 = ConfusionMatrix([1,2,2,1],[1,2,2,2])
+>>> cm2 = ConfusionMatrix([2,2,2,1],[2,2,2,2])
+>>> cm_combined1 = cm1.combine(cm2)
+>>> cm_combined2 = cm2.combine(cm1)
+>>> cm_combined1 == cm_combined2
+True
+>>> cm1.matrix[1][1]
+1
+>>> cm2.matrix[1][1]
+0
+>>> cm_combined1.matrix[1][1]
+1
+>>> cm1.matrix[1][2]
+1
+>>> cm2.matrix[1][2]
+1
+>>> cm_combined1.matrix[1][2]
+2
+>>> cm3 = ConfusionMatrix([2,3,2,1],[2,2,2,3])
+>>> cm3.matrix[1][3]
+1
+>>> cm_combined3 = cm3.combine(cm_combined2)
+>>> cm_combined3.matrix[1][3]
+1
 """

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1456,10 +1456,17 @@ True
 1
 >>> cm_combined1.matrix[1][2]
 2
->>> cm3 = ConfusionMatrix([2,3,2,1],[2,2,2,3])
->>> cm3.matrix[1][3]
+>>> cm3 = ConfusionMatrix([2,3,2,1,1,4,2],[2,2,2,3,1,2,3])
+>>> cm_combined3 = cm3.combine(cm_combined1)
+>>> cm_combined4 = cm_combined1.combine(cm3)
+>>> cm_combined3 == cm_combined4
+True
+>>> cm3.matrix[3][2]
 1
->>> cm_combined3 = cm3.combine(cm_combined2)
->>> cm_combined3.matrix[1][3]
+>>> cm_combined3.matrix[3][2]
+1
+>>> cm3.matrix[4][2]
+1
+>>> cm_combined3.matrix[4][2]
 1
 """

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -875,4 +875,6 @@ class ConfusionMatrix():
         :type other: Confusion matrix
         :return: combine of two matrices as a new Confusion matrix
         """
-        return ConfusionMatrix(matrix=matrix_combine(self, other))
+        if isinstance(other, ConfusionMatrix) is False:
+            raise pycmMatrixError(COMBINE_TYPE_ERROR)
+        return ConfusionMatrix(matrix=matrix_combine(self.matrix, other.matrix))

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -876,11 +876,15 @@ class ConfusionMatrix():
         :return: combine of two matrices as Confusion matrix
         """
         result_matrix = {}
-        classes = set(self.classes).intersection(set(other.classes))
+        classes = set(self.classes).union(set(other.classes))
         for class_1 in classes:
             temp_dict = {}
             for class_2 in classes:
-                temp_dict[class_2] = self.matrix[class_1][class_2] + \
-                    other.matrix[class_1][class_2]
+                tmp = 0
+                if class_1 in self.classes and class_2 in self.classes:
+                    tmp += self.matrix[class_1][class_2]
+                if class_1 in other.classes and class_2 in other.classes:
+                    tmp += other.matrix[class_1][class_2]
+                temp_dict[class_2] = tmp
             result_matrix[class_1] = temp_dict
         return ConfusionMatrix(matrix=result_matrix)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -877,4 +877,6 @@ class ConfusionMatrix():
         """
         if isinstance(other, ConfusionMatrix) is False:
             raise pycmMatrixError(COMBINE_TYPE_ERROR)
-        return ConfusionMatrix(matrix=matrix_combine(self.matrix, other.matrix))
+        return ConfusionMatrix(
+            matrix=matrix_combine(
+                self.matrix, other.matrix))

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -873,5 +873,14 @@ class ConfusionMatrix():
 
         :param other: Other matrix that is going to combine.
         :type other: Confusion matrix
-        :return: combine of two matrices as Confusion matrix 
+        :return: combine of two matrices as Confusion matrix
         """
+        result_matrix = {}
+        classes = self.classes
+        for class_1 in classes:
+            temp_dict = {}
+            for class_2 in classes:
+                temp_dict[class_2] = self.matrix[class_1][class_2] + \
+                    other.matrix[class_1][class_2]
+            result_matrix[class_1] = temp_dict
+        return ConfusionMatrix(matrix=result_matrix)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -871,20 +871,8 @@ class ConfusionMatrix():
         """
         Return the combine of self Confusion matrix and other one.
 
-        :param other: Other matrix that is going to combine.
+        :param other: Other matrix that is going to be combined.
         :type other: Confusion matrix
         :return: combine of two matrices as a new Confusion matrix
         """
-        result_matrix = {}
-        classes = set(self.classes).union(set(other.classes))
-        for class_1 in classes:
-            temp_dict = {}
-            for class_2 in classes:
-                tmp = 0
-                if class_1 in self.classes and class_2 in self.classes:
-                    tmp += self.matrix[class_1][class_2]
-                if class_1 in other.classes and class_2 in other.classes:
-                    tmp += other.matrix[class_1][class_2]
-                temp_dict[class_2] = tmp
-            result_matrix[class_1] = temp_dict
-        return ConfusionMatrix(matrix=result_matrix)
+        return ConfusionMatrix(matrix=matrix_combine(self, other))

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -873,7 +873,7 @@ class ConfusionMatrix():
 
         :param other: Other matrix that is going to combine.
         :type other: Confusion matrix
-        :return: combine of two matrices as Confusion matrix
+        :return: combine of two matrices as a new Confusion matrix
         """
         result_matrix = {}
         classes = set(self.classes).union(set(other.classes))

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -876,7 +876,7 @@ class ConfusionMatrix():
         :return: combine of two matrices as Confusion matrix
         """
         result_matrix = {}
-        classes = self.classes
+        classes = set(self.classes).intersection(set(other.classes))
         for class_1 in classes:
             temp_dict = {}
             for class_2 in classes:

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -866,3 +866,12 @@ class ConfusionMatrix():
             row = [table[key][i] for i in classes]
             array.append(row)
         return numpy.array(array)
+
+    def combine(self, other):
+        """
+        Return the combine of self Confusion matrix and other one.
+
+        :param other: Other matrix that is going to combine.
+        :type other: Confusion matrix
+        :return: combine of two matrices as Confusion matrix 
+        """

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -38,6 +38,8 @@ COMPARE_NUMBER_ERROR = "Lower than two confusion matrices is given for comparing
 
 COMPARE_WEIGHT_ERROR = "The weight type must be dictionary and also must be specified for all of the classes."
 
+COMBINE_TYPE_ERROR = "The input type is considered to be pycm.ConfusionMatrix object but it's not!"
+
 COMPARE_RESULT_WARNING = "Confusion matrices are too close and the best one can not be recognized."
 
 WEIGHTED_KAPPA_WARNING = "The weight format is wrong, the result is for unweighted kappa."

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -409,3 +409,28 @@ def statistic_recommend(classes, P):
     if binary_check(classes):
         return BINARY_RECOMMEND
     return MULTICLASS_RECOMMEND
+
+
+def matrix_combine(matrix_1, matrix_2):
+    """
+    Return the combine of two Confusion matrices.
+
+    :param matrix_1: First matrix that is going to be combined.
+    :type matrix_1: Confusion matrix
+    :param matrix_2: Second matrix that is going to be combined.
+    :type matrix_2: Confusion matrix
+    :return: combine of two matrices as a dict of dicts
+    """
+    result_matrix = {}
+    classes = set(matrix_1.classes).union(set(matrix_2.classes))
+    for class_1 in classes:
+        temp_dict = {}
+        for class_2 in classes:
+            tmp = 0
+            if class_1 in matrix_1.classes and class_2 in matrix_1.classes:
+                tmp += matrix_1.matrix[class_1][class_2]
+            if class_1 in matrix_2.classes and class_2 in matrix_2.classes:
+                tmp += matrix_2.matrix[class_1][class_2]
+            temp_dict[class_2] = tmp
+        result_matrix[class_1] = temp_dict
+    return result_matrix

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -416,21 +416,22 @@ def matrix_combine(matrix_1, matrix_2):
     Return the combine of two Confusion matrices.
 
     :param matrix_1: First matrix that is going to be combined.
-    :type matrix_1: Confusion matrix
+    :type matrix_1: dict
     :param matrix_2: Second matrix that is going to be combined.
-    :type matrix_2: Confusion matrix
+    :type matrix_2: dict
     :return: combine of two matrices as a dict of dicts
     """
     result_matrix = {}
-    classes = set(matrix_1.classes).union(set(matrix_2.classes))
+    classes_1, classes_2 = matrix_1.keys(), matrix_2.keys()
+    classes = set(classes_1).union(set(classes_2))
     for class_1 in classes:
         temp_dict = {}
         for class_2 in classes:
             tmp = 0
-            if class_1 in matrix_1.classes and class_2 in matrix_1.classes:
-                tmp += matrix_1.matrix[class_1][class_2]
-            if class_1 in matrix_2.classes and class_2 in matrix_2.classes:
-                tmp += matrix_2.matrix[class_1][class_2]
+            if class_1 in classes_1 and class_2 in classes_1:
+                tmp += matrix_1[class_1][class_2]
+            if class_1 in classes_2 and class_2 in classes_2:
+                tmp += matrix_2[class_1][class_2]
             temp_dict[class_2] = tmp
         result_matrix[class_1] = temp_dict
     return result_matrix


### PR DESCRIPTION
#### Reference Issues/PRs
#326 
#### What does this implement/fix? Explain your changes.
In this PR `combine` method added.
We have 2 approaches for implementing this method:
+ [Intersection](https://github.com/sepandhaghighi/pycm/commit/3e2d3009f4981c071eff32e0610492adb5ed8b09)
In this approach new matrix will be calculated from intersection of two combining matrix classes.
for example we have:
```
>>> cm1 = ConfusionMatrix([1,2,3,1],[1,3,2,2])
>>> cm1.matrix
{1: {1: 1, 2: 1, 3: 0}, 2: {1: 0, 2: 0, 3: 1}, 3: {1: 0, 2: 1, 3: 0}}
>>> cm2 = ConfusionMatrix([4,2,2,1],[1,1,2,4])
>>> cm2.matrix
{1: {1: 0, 2: 0, 4: 1}, 2: {1: 1, 2: 1, 4: 0}, 4: {1: 1, 2: 0, 4: 0}}
>>> cm_combined = cm1.combine(cm2)
>>> cm_combined.matrix
{1: {1: 1, 2: 1}, 2: {1: 1, 2: 1}}
```
+ [Union](https://github.com/sepandhaghighi/pycm/commit/18958ab505e7a09d9e1a626f9bb0b472b4e1e90e)
In this approach new matrix will be calculated from intersection of two combining matrix classes.
for example we have:
```
>>> cm1 = ConfusionMatrix([1,2,3,1],[1,3,2,2])
>>> cm1.matrix
{1: {1: 1, 2: 1, 3: 0}, 2: {1: 0, 2: 0, 3: 1}, 3: {1: 0, 2: 1, 3: 0}}
>>> cm2 = ConfusionMatrix([4,2,2,1],[1,1,2,4])
>>> cm2.matrix
{1: {1: 0, 2: 0, 4: 1}, 2: {1: 1, 2: 1, 4: 0}, 4: {1: 1, 2: 0, 4: 0}}
>>> cm_combined = cm1.combine(cm2)
>>> cm_combined.matrix
{1: {1: 1, 2: 1, 3: 0, 4: 1}, 2: {1: 1, 2: 1, 3: 1, 4: 0}, 3: {1: 0, 2: 1, 3: 0, 4: 0}, 4: {1: 1, 2: 0, 3: 0, 4: 0}}
```

Anyway tests are now based on second approach.

@sepandhaghighi what we should decide what should we do for bad input (none `ConfusionMatrix` input)?
Should I add new exception for this method?