### PR TITLE
set TPR_PPV_F1_micro equal to overall acc #346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `overall_statistics` function modified
+- Document modified
 ## [3.0] - 2020-10-26
 ### Added
 - `plot_test.py`

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -8240,6 +8240,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equals to [TPR Micro](#TPR_Micro), [F1 Micro](#F1_Micro) and [PPV Micro](#PPV_Micro)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 162,
    "metadata": {},
@@ -8390,6 +8397,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equals to [TPR Micro](#TPR_Micro), [F1 Micro](#F1_Micro) and [Overall ACC](#Overall_ACC)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 165,
    "metadata": {},
@@ -8437,6 +8451,13 @@
    "metadata": {},
    "source": [
     "$$TPR_{Micro}=\\frac{\\sum_{i=1}^{|C|}TP_i}{\\sum_{i=1}^{|C|}TP_i+FN_i}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equals to [PPV Micro](#PPV_Micro), [F1 Micro](#F1_Micro) and [Overall ACC](#Overall_ACC)"
    ]
   },
   {
@@ -8637,6 +8658,13 @@
    "metadata": {},
    "source": [
     "$$F_{1_{Micro}}=2\\frac{\\sum_{i=1}^{|C|}TPR_i\\times PPV_i}{\\sum_{i=1}^{|C|}TPR_i+PPV_i}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Equals to [PPV Micro](#PPV_Micro), [TPR Micro](#TPR_Micro) and [Overall ACC](#Overall_ACC)"
    ]
   },
   {

--- a/pycm/pycm_overall_func.py
+++ b/pycm/pycm_overall_func.py
@@ -969,7 +969,7 @@ def overall_statistics(**kwargs):
     AUNP = AUNP_calc(classes, P, POP, kwargs["AUC_dict"])
     RCI = RCI_calc(mutual_information, reference_entropy)
     C = pearson_C_calc(chi_squared, population)
-    TPR_PPV_F1_micro = micro_calc(item1=TP, item2=kwargs["FN"])
+    TPR_PPV_F1_micro = overall_accuracy
     TPR_macro = macro_calc(kwargs["TPR"])
     CSI = macro_calc(kwargs["ICSI_dict"])
     ARI = ARI_calc(classes, table, TOP, P, population)


### PR DESCRIPTION
#### Reference Issues/PRs
#346 Micro F1 equals accuracy

#### What does this implement/fix? Explain your changes.

In the interest of computational optimization and also considering the fact that `PPV_Micro` == `TPR_Micro` == `F1_Micro` == `Overall ACC` if and only if each sample was assigned to a single class; the value of `Overall ACC` is assigned to `PPV_Micro`, `TPR_Micro`, and `F1_Micro`

#### Any other comments?

