### PR TITLE
Use long class names in html output files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Notebook check
       run: |
         python Otherfiles/notebook_check.py
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
     - name: Other tests
       run: |
           python -m vulture pycm/ Otherfiles/ setup.py --min-confidence 65 --exclude=__init__.py --sort-by-size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `name` parameter removed from `html_init` function
 - `shortener` parameter added to `html_table` function
-- `shortener` parameter added to `save_html` function
+- `shortener` parameter added to `save_html` method
 - HTML report modified
 ## [3.1] - 2021-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `use_long_names` parameter added to `html_table` function
-- `use_long_names` parameter added to `save_html` function
+- `shortener` parameter added to `html_table` function
+- `shortener` parameter added to `save_html` function
 ### Changed
 - `name` parameter removed from `html_init` function
 - HTML report modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `use_long_names` parameter added to `html_table` function
 ### Changed
 - `name` parameter removed from `html_init` function
 - HTML report modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `use_long_names` parameter added to `html_table` function
+- `use_long_names` parameter added to `save_html` function
 ### Changed
 - `name` parameter removed from `html_init` function
 - HTML report modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `shortener` parameter added to `html_table` function
-- `shortener` parameter added to `save_html` function
+
 ### Changed
 - `name` parameter removed from `html_init` function
+- `shortener` parameter added to `html_table` function
+- `shortener` parameter added to `save_html` function
 - HTML report modified
 ## [3.1] - 2021-03-11
 ### Added

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -11773,7 +11773,8 @@
     "6. `color` : matrix color (R,G,B) (type : `tuple`/`str`, default : `(0,0,0)`), support <a href=\"https://en.wikipedia.org/wiki/X11_color_names\">X11 color names</a>\n",
     "7. `normalize` : save normalize matrix flag (type : `bool`, default : `False`)\n",
     "8. `summary` : summary mode flag (type : `bool`, default : `False`)\n",
-    "9. `alt_link` : alternative link for document flag (type : `bool`, default : `False`)"
+    "9. `alt_link` : alternative link for document flag (type : `bool`, default : `False`)\n",
+    "10. `shortener` : flag which shows if long names are used (type : `bool`, default : `True`)"
    ]
   },
   {
@@ -11827,6 +11828,15 @@
    "source": [
     "<ul>\n",
     "    <li><span style=\"color:red;\">Notice </span> :  `summary` and `alt_link` , new in <span style=\"color:red;\">version 2.4 </span> </li>\n",
+    "</ul>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<ul>\n",
+    "    <li><span style=\"color:red;\">Notice </span> :  `shortener`, new in <span style=\"color:red;\">version 3.2 </span> </li>\n",
     "</ul>"
    ]
   },

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -11774,7 +11774,7 @@
     "7. `normalize` : save normalize matrix flag (type : `bool`, default : `False`)\n",
     "8. `summary` : summary mode flag (type : `bool`, default : `False`)\n",
     "9. `alt_link` : alternative link for document flag (type : `bool`, default : `False`)\n",
-    "10. `shortener` : flag which shows if long names are used (type : `bool`, default : `True`)"
+    "10. `shortener` : class name shortener flag (type : `bool`, default : `True`)"
    ]
   },
   {

--- a/Test/output_test.py
+++ b/Test/output_test.py
@@ -66,7 +66,7 @@ True
 >>> save_stat=long_name_cm.save_html("test_long_name",address=False,color="Pink")
 >>> save_stat=={'Status': True, 'Message': None}
 True
->>> save_stat=long_name_cm.save_html("test_use_long_name",address=False,color="Pink",shortener=False)
+>>> save_stat=long_name_cm.save_html("test_shortener",address=False,color="Pink",shortener=False)
 >>> save_stat=={'Status': True, 'Message': None}
 True
 >>> save_stat=cm.save_html("/asdasd,qweqwe.eo/",address=True)
@@ -542,7 +542,7 @@ True
 >>> os.remove("test_filtered4.html")
 >>> os.remove("test_filtered5.html")
 >>> os.remove("test_long_name.html")
->>> os.remove("test_use_long_name.html")
+>>> os.remove("test_shortener.html")
 >>> os.remove("test_alt.html")
 >>> os.remove("test_summary.html")
 >>> os.remove("test_colored.html")

--- a/Test/output_test.py
+++ b/Test/output_test.py
@@ -66,6 +66,9 @@ True
 >>> save_stat=long_name_cm.save_html("test_long_name",address=False,color="Pink")
 >>> save_stat=={'Status': True, 'Message': None}
 True
+>>> save_stat=long_name_cm.save_html("test_use_long_name",address=False,color="Pink",use_long_names=True)
+>>> save_stat=={'Status': True, 'Message': None}
+True
 >>> save_stat=cm.save_html("/asdasd,qweqwe.eo/",address=True)
 >>> save_stat=={'Status': False, 'Message': "[Errno 2] No such file or directory: '/asdasd,qweqwe.eo/.html'"}
 True
@@ -539,6 +542,7 @@ True
 >>> os.remove("test_filtered4.html")
 >>> os.remove("test_filtered5.html")
 >>> os.remove("test_long_name.html")
+>>> os.remove("test_use_long_name.html")
 >>> os.remove("test_alt.html")
 >>> os.remove("test_summary.html")
 >>> os.remove("test_colored.html")

--- a/Test/output_test.py
+++ b/Test/output_test.py
@@ -66,7 +66,7 @@ True
 >>> save_stat=long_name_cm.save_html("test_long_name",address=False,color="Pink")
 >>> save_stat=={'Status': True, 'Message': None}
 True
->>> save_stat=long_name_cm.save_html("test_use_long_name",address=False,color="Pink",use_long_names=True)
+>>> save_stat=long_name_cm.save_html("test_use_long_name",address=False,color="Pink",shortener=False)
 >>> save_stat=={'Status': True, 'Message': None}
 True
 >>> save_stat=cm.save_html("/asdasd,qweqwe.eo/",address=True)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -315,7 +315,7 @@ class ConfusionMatrix():
         :type summary : bool
         :param alt_link: alternative link for document flag
         :type alt_link: bool
-        :param shortener: flag which shows if long names are used
+        :param shortener: class name shortener flag
         :type shortener: bool
         :return: saving Status as dict {"Status":bool , "Message":str}
         """

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -316,7 +316,7 @@ class ConfusionMatrix():
         :param alt_link: alternative link for document flag
         :type alt_link: bool
         :param shortener: flag which shows if long names are used
-        :type use_long_name: bool
+        :type shortener: bool
         :return: saving Status as dict {"Status":bool , "Message":str}
         """
         try:

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -292,7 +292,8 @@ class ConfusionMatrix():
                 0),
             normalize=False,
             summary=False,
-            alt_link=False):
+            alt_link=False,
+            use_long_names=False):
         """
         Save ConfusionMatrix in HTML file.
 
@@ -314,6 +315,8 @@ class ConfusionMatrix():
         :type summary : bool
         :param alt_link: alternative link for document flag
         :type alt_link: bool
+        :param use_long_names: flag which shows if long names are used
+        :type use_long_name: bool
         :return: saving Status as dict {"Status":bool , "Message":str}
         """
         try:
@@ -329,7 +332,13 @@ class ConfusionMatrix():
             html_file = open(name + ".html", "w", encoding="utf-8")
             html_file.write(html_init())
             html_file.write(html_dataset_type(self.binary, self.imbalance))
-            html_file.write(html_table(self.classes, table, color, normalize))
+            html_file.write(
+                html_table(
+                    self.classes,
+                    table,
+                    color,
+                    normalize,
+                    use_long_names))
             html_file.write(
                 html_overall_stat(
                     self.overall_stat,

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -293,7 +293,7 @@ class ConfusionMatrix():
             normalize=False,
             summary=False,
             alt_link=False,
-            use_long_names=False):
+            shortener=True):
         """
         Save ConfusionMatrix in HTML file.
 
@@ -315,7 +315,7 @@ class ConfusionMatrix():
         :type summary : bool
         :param alt_link: alternative link for document flag
         :type alt_link: bool
-        :param use_long_names: flag which shows if long names are used
+        :param shortener: flag which shows if long names are used
         :type use_long_name: bool
         :return: saving Status as dict {"Status":bool , "Message":str}
         """
@@ -338,7 +338,7 @@ class ConfusionMatrix():
                     table,
                     color,
                     normalize,
-                    use_long_names))
+                    shortener))
             html_file.write(
                 html_overall_stat(
                     self.overall_stat,

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -100,7 +100,7 @@ def html_table(
     :type rgb_color : tuple
     :param normalize : save normalize matrix flag
     :type normalize : bool
-    :param shortener: flag which shows if long names are used
+    :param shortener: class name shortener flag
     :type shortener: bool
     :return: html_table as str
     """

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -83,7 +83,12 @@ def html_table_color(row, item, color=(0, 0, 0)):
     return result
 
 
-def html_table(classes, table, rgb_color, normalize=False):
+def html_table(
+        classes,
+        table,
+        rgb_color,
+        normalize=False,
+        use_long_names=False):
     """
     Return HTML report file confusion matrix.
 
@@ -95,6 +100,8 @@ def html_table(classes, table, rgb_color, normalize=False):
     :type rgb_color : tuple
     :param normalize : save normalize matrix flag
     :type normalize : bool
+    :param use_long_names: flag which shows if long names are used
+    :type use_long_name: bool
     :return: html_table as str
     """
     result = ""
@@ -114,7 +121,7 @@ def html_table(classes, table, rgb_color, normalize=False):
     part_2 = ""
     for i in classes:
         class_name = str(i)
-        if len(class_name) > 6:
+        if len(class_name) > 6 and not use_long_names:
             class_name = class_name[:4] + "..."
         result += '<td style="border:1px solid ' \
                   'black;padding:10px;height:7em;width:7em;">' + \

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -101,7 +101,7 @@ def html_table(
     :param normalize : save normalize matrix flag
     :type normalize : bool
     :param shortener: flag which shows if long names are used
-    :type use_long_name: bool
+    :type shortener: bool
     :return: html_table as str
     """
     result = ""

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -88,7 +88,7 @@ def html_table(
         table,
         rgb_color,
         normalize=False,
-        use_long_names=False):
+        shortener=True):
     """
     Return HTML report file confusion matrix.
 
@@ -100,7 +100,7 @@ def html_table(
     :type rgb_color : tuple
     :param normalize : save normalize matrix flag
     :type normalize : bool
-    :param use_long_names: flag which shows if long names are used
+    :param shortener: flag which shows if long names are used
     :type use_long_name: bool
     :return: html_table as str
     """
@@ -121,7 +121,7 @@ def html_table(
     part_2 = ""
     for i in classes:
         class_name = str(i)
-        if len(class_name) > 6 and not use_long_names:
+        if len(class_name) > 6 and shortener:
             class_name = class_name[:4] + "..."
         result += '<td style="border:1px solid ' \
                   'black;padding:10px;height:7em;width:7em;">' + \


### PR DESCRIPTION
#### Reference Issues/PRs
#364 
#### What does this implement/fix? Explain your changes.
new boolean parameter named `use_long_names` added to `save_html` function which provides us to use long class names in html output files