### PR TITLE
Class labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- `classes` added to `matrix_params_calc` method
-- `classes` added to `__obj_vector_handler__` method
-- `classes` added to ConfusionMatrix `__init__` method
-- `CLASSES_WARNING` added to pycm_param
 ### Changed
+- `classes` parameter added to `matrix_params_calc` method
+- `classes` parameter added to `__obj_vector_handler__` method
+- `classes` parameter added to ConfusionMatrix `__init__` method
 - `name` parameter removed from `html_init` function
 - `shortener` parameter added to `html_table` function
 - `shortener` parameter added to `save_html` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- `classes` parameter added to `matrix_params_calc` method
-- `classes` parameter added to `__obj_vector_handler__` method
+- `classes` parameter added to `matrix_params_calc` function
+- `classes` parameter added to `__obj_vector_handler__` function
 - `classes` parameter added to ConfusionMatrix `__init__` method
 - `name` parameter removed from `html_init` function
 - `shortener` parameter added to `html_table` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `name` parameter removed from `html_init` function
 - `shortener` parameter added to `html_table` function
 - `shortener` parameter added to `save_html` method
+- Document modified
 - HTML report modified
 ## [3.1] - 2021-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `classes` added to ConfusionMatrix parameters
+- `classes` added to `matrix_params_calc` method
+- `classes` added to `__obj_vector_handler__` method
+- `classes` added to ConfusionMatrix `__init__` method
 - `CLASSES_WARNING` added to pycm_param
 ### Changed
 - `name` parameter removed from `html_init` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `classes` added to ConfusionMatrix parameters
+- `CLASSES_WARNING` added to pycm_param
 ### Changed
 - `name` parameter removed from `html_init` function
 - HTML report modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `classes_filter` function
 ### Changed
 - `classes` parameter added to `matrix_params_calc` function
 - `classes` parameter added to `__obj_vector_handler__` function

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -837,6 +837,69 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = ConfusionMatrix(y_actu, y_pred, classes=[1,0,2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.print_matrix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = ConfusionMatrix(y_actu, y_pred, classes=[0,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.print_matrix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = ConfusionMatrix(y_actu, y_pred, classes=[1,0,4])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.print_matrix()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<ul>\n",
+    "    <li><span style=\"color:red;\">Notice </span> : `classes` added in <span style=\"color:red;\">version 3.2</span></li>\n",
+    "</ul>"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2307,7 +2370,8 @@
     "5. `threshold` : `FunctionType (function or lambda)`\n",
     "6. `file` : `File object`\n",
     "7. `sample_weight` : python `list` or numpy `array` of numbers\n",
-    "8. `transpose` : `bool`"
+    "8. `transpose` : `bool`\n",
+    "9. `classes` : python `list`"
    ]
   },
   {
@@ -12757,11 +12821,35 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    cm6=ConfusionMatrix([1,1,1,1], [1,1,1,1], classes=[])\n",
+    "except pycmMatrixError as e:\n",
+    "    print(str(e))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    cm7=ConfusionMatrix([1,1,1,1], [1,1,1,1], classes=[1,1,2])\n",
+    "except pycmVectorError as e:\n",
+    "    print(str(e))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<ul>\n",
-    "    <li><span style=\"color:red;\">Notice </span> :  updated in <span style=\"color:red;\">version 3.0</span> </li>\n",
+    "    <li><span style=\"color:red;\">Notice </span> :  updated in <span style=\"color:red;\">version 3.2</span> </li>\n",
     "</ul>"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -316,7 +316,27 @@ Predict          0    ~
 Actual
 0                3    0    
 
-~                2    7    
+~                2    7  
+
+>>> cm = ConfusionMatrix(y_actu, y_pred, classes=[1,0,2])  # classes, new in version 3.2
+>>> cm.print_matrix()
+Predict 1       0       2       
+Actual
+1       1       0       2       
+
+0       0       3       0       
+
+2       1       2       3       
+
+>>> cm = ConfusionMatrix(y_actu, y_pred, classes=[1,0,4]) # classes, new in version 3.2
+>>> cm.print_matrix()
+Predict 1       0       4       
+Actual
+1       1       0       0       
+
+0       0       3       0       
+
+4       0       0       0       
 
 
 ```
@@ -673,6 +693,7 @@ pycm.ConfusionMatrix(classes: [0, 1, 2])
 6. `file` : `File object`
 7. `sample_weight` : python `list` or numpy `array` of numbers
 8. `transpose` : `bool`
+9. `classes` : python `list`
 
 * Run `help(ConfusionMatrix)` for `ConfusionMatrix` object details
 

--- a/Test/error_test.py
+++ b/Test/error_test.py
@@ -37,6 +37,10 @@ pycm.pycm_obj.pycmMatrixError: Type of the input matrix classes is assumed  be t
 Traceback (most recent call last):
         ...
 pycm.pycm_obj.pycmMatrixError: Number of the classes is lower than 2
+>>> cm = ConfusionMatrix([1,2,3,4], [1,2,3,4], classes=[1])
+Traceback (most recent call last):
+        ...
+pycm.pycm_error.pycmMatrixError: Number of the classes is lower than 2
 >>> y_actu = [2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2]
 >>> y_pred = [0, 0, 2, 1, 0, 2, 1, 0, 2, 0, 2, 2]
 >>> cm = ConfusionMatrix(y_actu,y_pred)

--- a/Test/error_test.py
+++ b/Test/error_test.py
@@ -25,6 +25,10 @@ pycm.pycm_obj.pycmVectorError: Input vectors must have same length
 Traceback (most recent call last):
         ...
 pycm.pycm_error.pycmVectorError: Input vectors are empty
+>>> cm = ConfusionMatrix([1,2,3,4], [1,2,3,4], classes=[1,2,2,2])
+Traceback (most recent call last):
+        ...
+pycm.pycm_error.pycmVectorError: The classes list isn't unique. It contains duplicated labels.
 >>> cm3=ConfusionMatrix(matrix={})
 Traceback (most recent call last):
         ...

--- a/Test/error_test.py
+++ b/Test/error_test.py
@@ -45,6 +45,10 @@ pycm.pycm_obj.pycmMatrixError: Number of the classes is lower than 2
 Traceback (most recent call last):
         ...
 pycm.pycm_error.pycmMatrixError: Number of the classes is lower than 2
+>>> cm = ConfusionMatrix([1,1,1,1],[1,2,1,1],classes=[])
+Traceback (most recent call last):
+        ...
+pycm.pycm_error.pycmMatrixError: Number of the classes is lower than 2
 >>> y_actu = [2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2]
 >>> y_pred = [0, 0, 2, 1, 0, 2, 1, 0, 2, 0, 2, 2]
 >>> cm = ConfusionMatrix(y_actu,y_pred)

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -705,4 +705,8 @@ array([[5, 1],
 >>> cm4.to_array()
 array([[3, 1],
        [0, 0]])
+>>> cm4 = ConfusionMatrix([1,1,1,1],["1",2,1,1],classes=[1,2])
+>>> cm4.to_array()
+array([[3, 1],
+       [0, 0]])
 """

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -701,4 +701,8 @@ pycm.ConfusionMatrix(classes: [1, 2])
 >>> cm4.to_array()
 array([[5, 1],
        [1, 4]])
+>>> cm4 = ConfusionMatrix(["1",1,1,1],[1,2,1,1],classes=[1,2])
+>>> cm.to_array()
+array([[3, 1],
+       [0, 0]])
 """

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -702,7 +702,7 @@ pycm.ConfusionMatrix(classes: [1, 2])
 array([[5, 1],
        [1, 4]])
 >>> cm4 = ConfusionMatrix(["1",1,1,1],[1,2,1,1],classes=[1,2])
->>> cm.to_array()
+>>> cm4.to_array()
 array([[3, 1],
        [0, 0]])
 """

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -684,4 +684,21 @@ pycm.ConfusionMatrix(classes: [0, 1, 2])
 0.4
 >>> cm3.LambdaB
 0.35714285714285715
+>>> cm4 = ConfusionMatrix(y_act,y_pre,classes=[1,2,0])
+>>> cm4
+pycm.ConfusionMatrix(classes: [1, 2, 0])
+>>> cm4.classes
+[1, 2, 0]
+>>> cm4.to_array()
+array([[5, 1, 3],
+       [1, 4, 1],
+       [3, 0, 9]])
+>>> cm4 = ConfusionMatrix(y_act,y_pre,classes=[1,2])
+>>> cm4
+pycm.ConfusionMatrix(classes: [1, 2])
+>>> cm4.classes
+[1, 2]
+>>> cm4.to_array()
+array([[5, 1],
+       [1, 4]])
 """

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -705,4 +705,12 @@ array([[5, 1],
 >>> cm4.to_array()
 array([[3, 1],
        [0, 0]])
+>>> cm4 = ConfusionMatrix([1,1,1,1],[1,1,2,1],classes=[1,"2"])
+>>> cm4.to_array()
+array([[3, 1],
+       [0, 0]])
+>>> cm4 = ConfusionMatrix([1,1,1,1],[1,"1",2,1],classes=[1,"2"])
+>>> cm4.to_array()
+array([[3, 1],
+       [0, 0]])
 """

--- a/Test/function_test.py
+++ b/Test/function_test.py
@@ -705,12 +705,4 @@ array([[5, 1],
 >>> cm4.to_array()
 array([[3, 1],
        [0, 0]])
->>> cm4 = ConfusionMatrix([1,1,1,1],[1,1,2,1],classes=[1,"2"])
->>> cm4.to_array()
-array([[3, 1],
-       [0, 0]])
->>> cm4 = ConfusionMatrix([1,1,1,1],[1,"1",2,1],classes=[1,"2"])
->>> cm4.to_array()
-array([[3, 1],
-       [0, 0]])
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -522,4 +522,11 @@ Y(Youden index)                                                   0.33333       
 dInd(Distance index)                                              0.4969        0.33672       0.36553       None
 sInd(Similarity index)                                            0.64864       0.7619        0.74153       None
 <BLANKLINE>
+>>> with warns(RuntimeWarning):
+...     cm4 = ConfusionMatrix([1,1,1,1],[1,1,2,1],classes=[1,"s"])
+>>> cm4.to_array()
+array([[3, 0],
+       [0, 0]])
+>>> cm4
+pycm.ConfusionMatrix(classes: ['1', 's'])
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -380,19 +380,19 @@ array([[5, 1, 3, 0],
 Predict 1       2       0       3       
 Actual
 1       5       1       3       0       
-
+<BLANKLINE>
 2       1       4       1       0       
-
+<BLANKLINE>
 0       3       0       9       0       
-
+<BLANKLINE>
 3       0       0       0       0       
-
-
-
-
-
+<BLANKLINE>
+<BLANKLINE>
+<BLANKLINE>
+<BLANKLINE>
+<BLANKLINE>
 Overall Statistics : 
-
+<BLANKLINE>
 95% CI                                                            (0.48885,0.84448)
 ACC Macro                                                         0.83333
 ARI                                                               0.21053
@@ -456,9 +456,9 @@ TNR Micro                                                         0.88889
 TPR Macro                                                         None
 TPR Micro                                                         0.66667
 Zero-one Loss                                                     9
-
+<BLANKLINE>
 Class Statistics :
-
+<BLANKLINE>
 Classes                                                           1             2             0             3             
 ACC(Accuracy)                                                     0.7037        0.88889       0.74074       1.0           
 AGF(Adjusted F-score)                                             0.65734       0.79543       0.75595       None          
@@ -521,5 +521,5 @@ TPR(Sensitivity, recall, hit rate, or true positive rate)         0.55556       
 Y(Youden index)                                                   0.33333       0.61905       0.48333       None          
 dInd(Distance index)                                              0.4969        0.33672       0.36553       None          
 sInd(Similarity index)                                            0.64864       0.7619        0.74153       None          
-
+<BLANKLINE>
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -377,21 +377,21 @@ array([[5, 1, 3, 0],
        [3, 0, 9, 0],
        [0, 0, 0, 0]])
 >>> print(cm4)
-Predict 1       2       0       3       
+Predict 1       2       0       3
 Actual
-1       5       1       3       0       
+1       5       1       3       0
 <BLANKLINE>
-2       1       4       1       0       
+2       1       4       1       0
 <BLANKLINE>
-0       3       0       9       0       
+0       3       0       9       0
 <BLANKLINE>
-3       0       0       0       0       
-<BLANKLINE>
-<BLANKLINE>
+3       0       0       0       0
 <BLANKLINE>
 <BLANKLINE>
 <BLANKLINE>
-Overall Statistics : 
+<BLANKLINE>
+<BLANKLINE>
+Overall Statistics :
 <BLANKLINE>
 95% CI                                                            (0.48885,0.84448)
 ACC Macro                                                         0.83333
@@ -459,67 +459,67 @@ Zero-one Loss                                                     9
 <BLANKLINE>
 Class Statistics :
 <BLANKLINE>
-Classes                                                           1             2             0             3             
-ACC(Accuracy)                                                     0.7037        0.88889       0.74074       1.0           
-AGF(Adjusted F-score)                                             0.65734       0.79543       0.75595       None          
-AGM(Adjusted geometric mean)                                      0.70552       0.86488       0.73866       None          
-AM(Difference between automatic and manual classification)        0             -1            1             0             
-AUC(Area under the ROC curve)                                     0.66667       0.80952       0.74167       None          
-AUCI(AUC value interpretation)                                    Fair          Very Good     Good          None          
-AUPR(Area under the PR curve)                                     0.55556       0.73333       0.72115       None          
-BCD(Bray-Curtis dissimilarity)                                    0.0           0.01852       0.01852       0.0           
-BM(Informedness or bookmaker informedness)                        0.33333       0.61905       0.48333       None          
-CEN(Confusion entropy)                                            0.51257       0.36499       0.35586       None          
-DOR(Diagnostic odds ratio)                                        4.375         40.0          8.25          None          
-DP(Discriminant power)                                            0.35339       0.88326       0.50527       None          
-DPI(Discriminant power interpretation)                            Poor          Poor          Poor          None          
-ERR(Error rate)                                                   0.2963        0.11111       0.25926       0.0           
-F0.5(F0.5 score)                                                  0.55556       0.76923       0.70312       None          
-F1(F1 score - harmonic mean of precision and sensitivity)         0.55556       0.72727       0.72          None          
-F2(F2 score)                                                      0.55556       0.68966       0.7377        None          
-FDR(False discovery rate)                                         0.44444       0.2           0.30769       None          
-FN(False negative/miss/type 2 error)                              4             2             3             0             
-FNR(Miss rate or false negative rate)                             0.44444       0.33333       0.25          None          
-FOR(False omission rate)                                          0.22222       0.09091       0.21429       0.0           
-FP(False positive/type 1 error/false alarm)                       4             1             4             0             
-FPR(Fall-out or false positive rate)                              0.22222       0.04762       0.26667       0.0           
-G(G-measure geometric mean of precision and sensitivity)          0.55556       0.7303        0.72058       None          
-GI(Gini index)                                                    0.33333       0.61905       0.48333       None          
-GM(G-mean geometric mean of specificity and sensitivity)          0.65734       0.79682       0.74162       None          
-IBA(Index of balanced accuracy)                                   0.33608       0.45351       0.55917       None          
-ICSI(Individual classification success index)                     0.11111       0.46667       0.44231       None          
-IS(Information score)                                             0.73697       1.848         0.63941       None          
-J(Jaccard index)                                                  0.38462       0.57143       0.5625        None          
-LS(Lift score)                                                    1.66667       3.6           1.55769       None          
-MCC(Matthews correlation coefficient)                             0.33333       0.66254       0.48067       None          
-MCCI(Matthews correlation coefficient interpretation)             Weak          Moderate      Weak          None          
-MCEN(Modified confusion entropy)                                  0.59795       0.46544       0.44706       None          
-MK(Markedness)                                                    0.33333       0.70909       0.47802       None          
-N(Condition negative)                                             18            21            15            27            
-NLR(Negative likelihood ratio)                                    0.57143       0.35          0.34091       None          
-NLRI(Negative likelihood ratio interpretation)                    Negligible    Poor          Poor          None          
-NPV(Negative predictive value)                                    0.77778       0.90909       0.78571       1.0           
-OC(Overlap coefficient)                                           0.55556       0.8           0.75          None          
-OOC(Otsuka-Ochiai coefficient)                                    0.55556       0.7303        0.72058       None          
-OP(Optimized precision)                                           0.53704       0.71242       0.7295        None          
-P(Condition positive or support)                                  9             6             12            0             
-PLR(Positive likelihood ratio)                                    2.5           14.0          2.8125        None          
-PLRI(Positive likelihood ratio interpretation)                    Poor          Good          Poor          None          
-POP(Population)                                                   27            27            27            27            
-PPV(Precision or positive predictive value)                       0.55556       0.8           0.69231       None          
-PRE(Prevalence)                                                   0.33333       0.22222       0.44444       0.0           
-Q(Yule Q - coefficient of colligation)                            0.62791       0.95122       0.78378       None          
-QI(Yule Q interpretation)                                         Moderate      Strong        Strong        None          
-RACC(Random accuracy)                                             0.11111       0.04115       0.21399       0.0           
-RACCU(Random accuracy unbiased)                                   0.11111       0.0415        0.21433       0.0           
-TN(True negative/correct rejection)                               14            20            11            27            
-TNR(Specificity or true negative rate)                            0.77778       0.95238       0.73333       1.0           
-TON(Test outcome negative)                                        18            22            14            27            
-TOP(Test outcome positive)                                        9             5             13            0             
-TP(True positive/hit)                                             5             4             9             0             
-TPR(Sensitivity, recall, hit rate, or true positive rate)         0.55556       0.66667       0.75          None          
-Y(Youden index)                                                   0.33333       0.61905       0.48333       None          
-dInd(Distance index)                                              0.4969        0.33672       0.36553       None          
-sInd(Similarity index)                                            0.64864       0.7619        0.74153       None          
+Classes                                                           1             2             0             3
+ACC(Accuracy)                                                     0.7037        0.88889       0.74074       1.0
+AGF(Adjusted F-score)                                             0.65734       0.79543       0.75595       None
+AGM(Adjusted geometric mean)                                      0.70552       0.86488       0.73866       None
+AM(Difference between automatic and manual classification)        0             -1            1             0
+AUC(Area under the ROC curve)                                     0.66667       0.80952       0.74167       None
+AUCI(AUC value interpretation)                                    Fair          Very Good     Good          None
+AUPR(Area under the PR curve)                                     0.55556       0.73333       0.72115       None
+BCD(Bray-Curtis dissimilarity)                                    0.0           0.01852       0.01852       0.0
+BM(Informedness or bookmaker informedness)                        0.33333       0.61905       0.48333       None
+CEN(Confusion entropy)                                            0.51257       0.36499       0.35586       None
+DOR(Diagnostic odds ratio)                                        4.375         40.0          8.25          None
+DP(Discriminant power)                                            0.35339       0.88326       0.50527       None
+DPI(Discriminant power interpretation)                            Poor          Poor          Poor          None
+ERR(Error rate)                                                   0.2963        0.11111       0.25926       0.0
+F0.5(F0.5 score)                                                  0.55556       0.76923       0.70312       None
+F1(F1 score - harmonic mean of precision and sensitivity)         0.55556       0.72727       0.72          None
+F2(F2 score)                                                      0.55556       0.68966       0.7377        None
+FDR(False discovery rate)                                         0.44444       0.2           0.30769       None
+FN(False negative/miss/type 2 error)                              4             2             3             0
+FNR(Miss rate or false negative rate)                             0.44444       0.33333       0.25          None
+FOR(False omission rate)                                          0.22222       0.09091       0.21429       0.0
+FP(False positive/type 1 error/false alarm)                       4             1             4             0
+FPR(Fall-out or false positive rate)                              0.22222       0.04762       0.26667       0.0
+G(G-measure geometric mean of precision and sensitivity)          0.55556       0.7303        0.72058       None
+GI(Gini index)                                                    0.33333       0.61905       0.48333       None
+GM(G-mean geometric mean of specificity and sensitivity)          0.65734       0.79682       0.74162       None
+IBA(Index of balanced accuracy)                                   0.33608       0.45351       0.55917       None
+ICSI(Individual classification success index)                     0.11111       0.46667       0.44231       None
+IS(Information score)                                             0.73697       1.848         0.63941       None
+J(Jaccard index)                                                  0.38462       0.57143       0.5625        None
+LS(Lift score)                                                    1.66667       3.6           1.55769       None
+MCC(Matthews correlation coefficient)                             0.33333       0.66254       0.48067       None
+MCCI(Matthews correlation coefficient interpretation)             Weak          Moderate      Weak          None
+MCEN(Modified confusion entropy)                                  0.59795       0.46544       0.44706       None
+MK(Markedness)                                                    0.33333       0.70909       0.47802       None
+N(Condition negative)                                             18            21            15            27
+NLR(Negative likelihood ratio)                                    0.57143       0.35          0.34091       None
+NLRI(Negative likelihood ratio interpretation)                    Negligible    Poor          Poor          None
+NPV(Negative predictive value)                                    0.77778       0.90909       0.78571       1.0
+OC(Overlap coefficient)                                           0.55556       0.8           0.75          None
+OOC(Otsuka-Ochiai coefficient)                                    0.55556       0.7303        0.72058       None
+OP(Optimized precision)                                           0.53704       0.71242       0.7295        None
+P(Condition positive or support)                                  9             6             12            0
+PLR(Positive likelihood ratio)                                    2.5           14.0          2.8125        None
+PLRI(Positive likelihood ratio interpretation)                    Poor          Good          Poor          None
+POP(Population)                                                   27            27            27            27
+PPV(Precision or positive predictive value)                       0.55556       0.8           0.69231       None
+PRE(Prevalence)                                                   0.33333       0.22222       0.44444       0.0
+Q(Yule Q - coefficient of colligation)                            0.62791       0.95122       0.78378       None
+QI(Yule Q interpretation)                                         Moderate      Strong        Strong        None
+RACC(Random accuracy)                                             0.11111       0.04115       0.21399       0.0
+RACCU(Random accuracy unbiased)                                   0.11111       0.0415        0.21433       0.0
+TN(True negative/correct rejection)                               14            20            11            27
+TNR(Specificity or true negative rate)                            0.77778       0.95238       0.73333       1.0
+TON(Test outcome negative)                                        18            22            14            27
+TOP(Test outcome positive)                                        9             5             13            0
+TP(True positive/hit)                                             5             4             9             0
+TPR(Sensitivity, recall, hit rate, or true positive rate)         0.55556       0.66667       0.75          None
+Y(Youden index)                                                   0.33333       0.61905       0.48333       None
+dInd(Distance index)                                              0.4969        0.33672       0.36553       None
+sInd(Similarity index)                                            0.64864       0.7619        0.74153       None
 <BLANKLINE>
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -529,4 +529,11 @@ array([[3, 0],
        [0, 0]])
 >>> cm4
 pycm.ConfusionMatrix(classes: ['1', 's'])
+>>> with warns(RuntimeWarning):
+...     cm4 = ConfusionMatrix([1,1,1,1],[1,1,2,1],classes=(1,2))
+>>> cm4.to_array()
+array([[3, 1],
+       [0, 0]])
+>>> cm4
+pycm.ConfusionMatrix(classes: [1, 2])
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -363,4 +363,163 @@ sInd(Similarity index)                                            1.0           
 >>> with warns(RuntimeWarning):
 ...	    cm.weighted_alpha(weight={1:{1:1,2:2},2:{1:2,2:1}})
 0.5007878978884337
+>>> y_act=[0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2]
+>>> y_pre=[0,0,0,0,0,0,0,0,0,1,1,1,0,0,0,1,1,1,1,1,2,0,1,2,2,2,2]
+>>> with warns(RuntimeWarning):
+...     cm4 = ConfusionMatrix(y_act,y_pre,classes=[1,2,0,3])
+>>> cm4
+pycm.ConfusionMatrix(classes: [1, 2, 0, 3])
+>>> cm4.classes
+[1, 2, 0, 3]
+>>> cm4.to_array()
+array([[5, 1, 3, 0],
+       [1, 4, 1, 0],
+       [3, 0, 9, 0],
+       [0, 0, 0, 0]])
+>>> print(cm4)
+Predict 1       2       0       3       
+Actual
+1       5       1       3       0       
+
+2       1       4       1       0       
+
+0       3       0       9       0       
+
+3       0       0       0       0       
+
+
+
+
+
+Overall Statistics : 
+
+95% CI                                                            (0.48885,0.84448)
+ACC Macro                                                         0.83333
+ARI                                                               0.21053
+AUNP                                                              None
+AUNU                                                              None
+Bangdiwala B                                                      0.45693
+Bennett S                                                         0.55556
+CBA                                                               None
+CSI                                                               None
+Chi-Squared                                                       None
+Chi-Squared DF                                                    9
+Conditional Entropy                                               1.08926
+Cramer V                                                          None
+Cross Entropy                                                     1.53762
+F1 Macro                                                          None
+F1 Micro                                                          0.66667
+FNR Macro                                                         None
+FNR Micro                                                         0.33333
+FPR Macro                                                         0.13413
+FPR Micro                                                         0.11111
+Gwet AC1                                                          0.57751
+Hamming Loss                                                      0.33333
+Joint Entropy                                                     2.61975
+KL Divergence                                                     None
+Kappa                                                             0.47403
+Kappa 95% CI                                                      (0.19345,0.7546)
+Kappa No Prevalence                                               0.33333
+Kappa Standard Error                                              0.14315
+Kappa Unbiased                                                    0.47346
+Krippendorff Alpha                                                0.48321
+Lambda A                                                          0.4
+Lambda B                                                          0.35714
+Mutual Information                                                0.39731
+NIR                                                               0.44444
+Overall ACC                                                       0.66667
+Overall CEN                                                       None
+Overall J                                                         None
+Overall MCC                                                       0.47511
+Overall MCEN                                                      None
+Overall RACC                                                      0.36626
+Overall RACCU                                                     0.36694
+P-Value                                                           0.01667
+PPV Macro                                                         None
+PPV Micro                                                         0.66667
+Pearson C                                                         None
+Phi-Squared                                                       None
+RCI                                                               0.2596
+RR                                                                6.75
+Reference Entropy                                                 1.53049
+Response Entropy                                                  1.48657
+SOA1(Landis & Koch)                                               Moderate
+SOA2(Fleiss)                                                      Intermediate to Good
+SOA3(Altman)                                                      Moderate
+SOA4(Cicchetti)                                                   Fair
+SOA5(Cramer)                                                      None
+SOA6(Matthews)                                                    Weak
+Scott PI                                                          0.47346
+Standard Error                                                    0.09072
+TNR Macro                                                         0.86587
+TNR Micro                                                         0.88889
+TPR Macro                                                         None
+TPR Micro                                                         0.66667
+Zero-one Loss                                                     9
+
+Class Statistics :
+
+Classes                                                           1             2             0             3             
+ACC(Accuracy)                                                     0.7037        0.88889       0.74074       1.0           
+AGF(Adjusted F-score)                                             0.65734       0.79543       0.75595       None          
+AGM(Adjusted geometric mean)                                      0.70552       0.86488       0.73866       None          
+AM(Difference between automatic and manual classification)        0             -1            1             0             
+AUC(Area under the ROC curve)                                     0.66667       0.80952       0.74167       None          
+AUCI(AUC value interpretation)                                    Fair          Very Good     Good          None          
+AUPR(Area under the PR curve)                                     0.55556       0.73333       0.72115       None          
+BCD(Bray-Curtis dissimilarity)                                    0.0           0.01852       0.01852       0.0           
+BM(Informedness or bookmaker informedness)                        0.33333       0.61905       0.48333       None          
+CEN(Confusion entropy)                                            0.51257       0.36499       0.35586       None          
+DOR(Diagnostic odds ratio)                                        4.375         40.0          8.25          None          
+DP(Discriminant power)                                            0.35339       0.88326       0.50527       None          
+DPI(Discriminant power interpretation)                            Poor          Poor          Poor          None          
+ERR(Error rate)                                                   0.2963        0.11111       0.25926       0.0           
+F0.5(F0.5 score)                                                  0.55556       0.76923       0.70312       None          
+F1(F1 score - harmonic mean of precision and sensitivity)         0.55556       0.72727       0.72          None          
+F2(F2 score)                                                      0.55556       0.68966       0.7377        None          
+FDR(False discovery rate)                                         0.44444       0.2           0.30769       None          
+FN(False negative/miss/type 2 error)                              4             2             3             0             
+FNR(Miss rate or false negative rate)                             0.44444       0.33333       0.25          None          
+FOR(False omission rate)                                          0.22222       0.09091       0.21429       0.0           
+FP(False positive/type 1 error/false alarm)                       4             1             4             0             
+FPR(Fall-out or false positive rate)                              0.22222       0.04762       0.26667       0.0           
+G(G-measure geometric mean of precision and sensitivity)          0.55556       0.7303        0.72058       None          
+GI(Gini index)                                                    0.33333       0.61905       0.48333       None          
+GM(G-mean geometric mean of specificity and sensitivity)          0.65734       0.79682       0.74162       None          
+IBA(Index of balanced accuracy)                                   0.33608       0.45351       0.55917       None          
+ICSI(Individual classification success index)                     0.11111       0.46667       0.44231       None          
+IS(Information score)                                             0.73697       1.848         0.63941       None          
+J(Jaccard index)                                                  0.38462       0.57143       0.5625        None          
+LS(Lift score)                                                    1.66667       3.6           1.55769       None          
+MCC(Matthews correlation coefficient)                             0.33333       0.66254       0.48067       None          
+MCCI(Matthews correlation coefficient interpretation)             Weak          Moderate      Weak          None          
+MCEN(Modified confusion entropy)                                  0.59795       0.46544       0.44706       None          
+MK(Markedness)                                                    0.33333       0.70909       0.47802       None          
+N(Condition negative)                                             18            21            15            27            
+NLR(Negative likelihood ratio)                                    0.57143       0.35          0.34091       None          
+NLRI(Negative likelihood ratio interpretation)                    Negligible    Poor          Poor          None          
+NPV(Negative predictive value)                                    0.77778       0.90909       0.78571       1.0           
+OC(Overlap coefficient)                                           0.55556       0.8           0.75          None          
+OOC(Otsuka-Ochiai coefficient)                                    0.55556       0.7303        0.72058       None          
+OP(Optimized precision)                                           0.53704       0.71242       0.7295        None          
+P(Condition positive or support)                                  9             6             12            0             
+PLR(Positive likelihood ratio)                                    2.5           14.0          2.8125        None          
+PLRI(Positive likelihood ratio interpretation)                    Poor          Good          Poor          None          
+POP(Population)                                                   27            27            27            27            
+PPV(Precision or positive predictive value)                       0.55556       0.8           0.69231       None          
+PRE(Prevalence)                                                   0.33333       0.22222       0.44444       0.0           
+Q(Yule Q - coefficient of colligation)                            0.62791       0.95122       0.78378       None          
+QI(Yule Q interpretation)                                         Moderate      Strong        Strong        None          
+RACC(Random accuracy)                                             0.11111       0.04115       0.21399       0.0           
+RACCU(Random accuracy unbiased)                                   0.11111       0.0415        0.21433       0.0           
+TN(True negative/correct rejection)                               14            20            11            27            
+TNR(Specificity or true negative rate)                            0.77778       0.95238       0.73333       1.0           
+TON(Test outcome negative)                                        18            22            14            27            
+TOP(Test outcome positive)                                        9             5             13            0             
+TP(True positive/hit)                                             5             4             9             0             
+TPR(Sensitivity, recall, hit rate, or true positive rate)         0.55556       0.66667       0.75          None          
+Y(Youden index)                                                   0.33333       0.61905       0.48333       None          
+dInd(Distance index)                                              0.4969        0.33672       0.36553       None          
+sInd(Similarity index)                                            0.64864       0.7619        0.74153       None          
+
 """

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -295,6 +295,8 @@ def __obj_vector_handler__(
         raise pycmVectorError(VECTOR_SIZE_ERROR)
     if len(actual_vector) == 0 or len(predict_vector) == 0:
         raise pycmVectorError(VECTOR_EMPTY_ERROR)
+    if list(set(classes)) != classes:
+        raise pycmVectorError(VECTOR_UNIQUE_CLASS_ERROR)
     matrix_param = matrix_params_calc(
         actual_vector, predict_vector, sample_weight, classes)
     if isinstance(sample_weight, (list, numpy.ndarray)):

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -9,7 +9,6 @@ from .pycm_param import *
 import json
 import types
 import numpy
-from warnings import warn
 
 
 def __class_stat_init__(cm):
@@ -297,12 +296,8 @@ def __obj_vector_handler__(
     if len(actual_vector) == 0 or len(predict_vector) == 0:
         raise pycmVectorError(VECTOR_EMPTY_ERROR)
     matrix_param = matrix_params_calc(
-        actual_vector, predict_vector, sample_weight)
+        actual_vector, predict_vector, sample_weight, classes)
     if isinstance(sample_weight, (list, numpy.ndarray)):
         cm.weights = sample_weight
-    if isinstance(classes, list):
-        if not set(classes).issubset(set(matrix_param[0])):
-            warn(CLASSES_WARNING, RuntimeWarning)
-        matrix_param[0] = classes
 
     return matrix_param

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -295,7 +295,7 @@ def __obj_vector_handler__(
         raise pycmVectorError(VECTOR_SIZE_ERROR)
     if len(actual_vector) == 0 or len(predict_vector) == 0:
         raise pycmVectorError(VECTOR_EMPTY_ERROR)
-    if classes is not None and list(set(classes)) != classes:
+    if classes is not None and len(set(classes)) != len(classes):
         raise pycmVectorError(VECTOR_UNIQUE_CLASS_ERROR)
     matrix_param = matrix_params_calc(
         actual_vector, predict_vector, sample_weight, classes)

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -295,7 +295,7 @@ def __obj_vector_handler__(
         raise pycmVectorError(VECTOR_SIZE_ERROR)
     if len(actual_vector) == 0 or len(predict_vector) == 0:
         raise pycmVectorError(VECTOR_EMPTY_ERROR)
-    if list(set(classes)) != classes:
+    if classes != None and list(set(classes)) != classes:
         raise pycmVectorError(VECTOR_UNIQUE_CLASS_ERROR)
     matrix_param = matrix_params_calc(
         actual_vector, predict_vector, sample_weight, classes)

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -295,7 +295,7 @@ def __obj_vector_handler__(
         raise pycmVectorError(VECTOR_SIZE_ERROR)
     if len(actual_vector) == 0 or len(predict_vector) == 0:
         raise pycmVectorError(VECTOR_EMPTY_ERROR)
-    if classes != None and list(set(classes)) != classes:
+    if classes is not None and list(set(classes)) != classes:
         raise pycmVectorError(VECTOR_UNIQUE_CLASS_ERROR)
     matrix_param = matrix_params_calc(
         actual_vector, predict_vector, sample_weight, classes)

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -9,6 +9,7 @@ from .pycm_param import *
 import json
 import types
 import numpy
+from warnings import warn
 
 
 def __class_stat_init__(cm):
@@ -266,7 +267,8 @@ def __obj_vector_handler__(
         actual_vector,
         predict_vector,
         threshold,
-        sample_weight):
+        sample_weight,
+        classes):
     """
     Handle object conditions for vectors.
 
@@ -280,6 +282,8 @@ def __obj_vector_handler__(
     :type threshold : FunctionType (function or lambda)
     :param sample_weight : sample weights list
     :type sample_weight : list
+    :param classes: ordered labels of classes
+    :type classes: list
     :return: matrix parameters as list
     """
     if isinstance(threshold, types.FunctionType):
@@ -296,5 +300,9 @@ def __obj_vector_handler__(
         actual_vector, predict_vector, sample_weight)
     if isinstance(sample_weight, (list, numpy.ndarray)):
         cm.weights = sample_weight
+    if isinstance(classes, list):
+        if not set(classes).issubset(set(matrix_param[0])):
+            warn(CLASSES_WARNING, RuntimeWarning)
+        matrix_param[0] = classes
 
     return matrix_param

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -936,6 +936,7 @@ class ConfusionMatrix():
             normalized=normalized,
             one_vs_all=one_vs_all,
             class_name=class_name)
+        classes = self.classes
         if normalized:
             title += " (Normalized)"
         if one_vs_all and class_name in classes:

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -59,7 +59,7 @@ class ConfusionMatrix():
         :type sample_weight : list
         :param transpose : transpose flag
         :type transpose : bool
-        :param classes: ordered labels of classes that are going to be used
+        :param classes: ordered labels of classes
         :type classes: list
         """
         self.actual_vector = actual_vector
@@ -77,17 +77,12 @@ class ConfusionMatrix():
             matrix_param = __obj_matrix_handler__(matrix, transpose)
         else:
             matrix_param = __obj_vector_handler__(
-                self, actual_vector, predict_vector, threshold, sample_weight)
+                self, actual_vector, predict_vector, threshold, sample_weight, classes)
         if len(matrix_param[0]) < 2:
             raise pycmMatrixError(CLASS_NUMBER_ERROR)
         __obj_assign_handler__(self, matrix_param)
         __class_stat_init__(self)
         __overall_stat_init__(self)
-        if classes is not None:
-            if set(classes) == set(self.classes):
-                self.classes = classes
-            else:
-                warn(CLASSES_WARNING.format(self.classes), RuntimeWarning)
         self.imbalance = imbalance_check(self.P)
         self.binary = binary_check(self.classes)
         self.recommended_list = statistic_recommend(self.classes, self.P)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -871,7 +871,7 @@ class ConfusionMatrix():
         :type class_name : any valid type
         :return: confusion matrix as a numpy.ndarray
         """
-        classes = sorted(self.classes)
+        classes = self.classes
         table = self.table
         if normalized:
             table = self.normalized_table

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -938,7 +938,6 @@ class ConfusionMatrix():
             class_name=class_name)
         if normalized:
             title += " (Normalized)"
-        classes = sorted(self.classes)
         if one_vs_all and class_name in classes:
             classes = [class_name, '~']
         try:

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -38,7 +38,8 @@ class ConfusionMatrix():
             predict_vector=None,
             matrix=None,
             digit=5, threshold=None, file=None,
-            sample_weight=None, transpose=False):
+            sample_weight=None, transpose=False,
+            classes=None):
         """
         Init method.
 
@@ -58,6 +59,8 @@ class ConfusionMatrix():
         :type sample_weight : list
         :param transpose : transpose flag
         :type transpose : bool
+        :param classes: ordered labels of classes that are going to be used
+        :type classes: list
         """
         self.actual_vector = actual_vector
         self.predict_vector = predict_vector
@@ -80,6 +83,11 @@ class ConfusionMatrix():
         __obj_assign_handler__(self, matrix_param)
         __class_stat_init__(self)
         __overall_stat_init__(self)
+        if classes is not None:
+            if set(classes) == set(self.classes):
+                self.classes = classes
+            else:
+                warn(CLASSES_WARNING.format(self.classes), RuntimeWarning)
         self.imbalance = imbalance_check(self.P)
         self.binary = binary_check(self.classes)
         self.recommended_list = statistic_recommend(self.classes, self.P)

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -109,7 +109,6 @@ def html_table(classes, table, rgb_color, normalize=False):
     table_size = str((len(classes) + 1) * 7) + "em"
     result += '<table style="border:1px solid black;border-collapse: collapse;height:{0};width:{0};">\n'\
         .format(table_size)
-    classes.sort()
     result += '<tr style="text-align:center;">\n<td></td>\n'
     part_2 = ""
     for i in classes:
@@ -230,7 +229,6 @@ def html_class_stat(
     if isinstance(class_param, list):
         if set(class_param) <= set(class_stat_keys):
             class_stat_keys = class_param
-    classes.sort()
     if len(classes) < 1 or len(class_stat_keys) < 1:
         return ""
     for i in class_stat_keys:
@@ -294,7 +292,6 @@ def table_print(classes, table):
     table_list = []
     for key in classes:
         table_list.extend(list(table[key].values()))
-    classes.sort()
     table_list.extend(classes)
     table_max_length = max(map(len, map(str, table_list)))
     shift = "%-" + str(7 + table_max_length) + "s"
@@ -350,7 +347,6 @@ def csv_matrix_print(classes, table, header=False):
     """
     result = ""
     header_section = ""
-    classes.sort()
     for i in classes:
         if header is True:
             header_section += '"' + str(i) + '"' + ","
@@ -378,7 +374,6 @@ def csv_print(classes, class_stat, digit=5, class_param=None):
     :return: csv file data as str
     """
     result = "Class"
-    classes.sort()
     for item in classes:
         result += ',"' + str(item) + '"'
     result += "\n"
@@ -435,7 +430,6 @@ def stat_print(
     if isinstance(class_param, list):
         if set(class_param) <= set(class_stat_keys):
             class_stat_keys = sorted(class_param)
-    classes.sort()
     if len(class_stat_keys) > 0 and len(classes) > 0:
         class_shift = max(
             max(map(lambda x: len(str(x)), classes)) + 5, digit + 6, 14)

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -84,8 +84,7 @@ CLASS_NUMBER_WARNING = "The confusion matrix is a high dimension matrix and won'
                        "If confusion matrix has too many zeros (sparse matrix) you can set `sparse` flag to True in printing functions "\
                        "otherwise by using save_csv method to save the confusion matrix in csv format you'll have better demonstration."
 
-CLASSES_WARNING = "The class labels do not match used labels in actual and predict vectors.\n" \
-                  "Class labels are going to be assigned with {}."
+CLASSES_WARNING = "Used classes is not a subset of classes in actual and predict vectors."
 
 CLASS_NUMBER_THRESHOLD = 10
 

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -57,6 +57,7 @@ VECTOR_TYPE_ERROR = "The type of input vectors is assumed to be a list or a NumP
 VECTOR_SIZE_ERROR = "Input vectors must have same length"
 VECTOR_EMPTY_ERROR = "Input vectors are empty"
 VECTOR_ONLY_ERROR = "This option only works in vector mode"
+VECTOR_UNIQUE_CLASS_ERROR = "The classes list isn't unique. It contains duplicated labels."
 CLASS_NUMBER_ERROR = "Number of the classes is lower than 2"
 COMPARE_FORMAT_ERROR = "The input type is supposed to be dictionary but it's not!"
 

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -84,6 +84,9 @@ CLASS_NUMBER_WARNING = "The confusion matrix is a high dimension matrix and won'
                        "If confusion matrix has too many zeros (sparse matrix) you can set `sparse` flag to True in printing functions "\
                        "otherwise by using save_csv method to save the confusion matrix in csv format you'll have better demonstration."
 
+CLASSES_WARNING = "The class labels do not match used labels in actual and predict vectors.\n" \
+                  "Class labels are going to be assigned with {}"
+
 CLASS_NUMBER_THRESHOLD = 10
 
 BALANCE_RATIO_THRESHOLD = 3

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -85,7 +85,7 @@ CLASS_NUMBER_WARNING = "The confusion matrix is a high dimension matrix and won'
                        "otherwise by using save_csv method to save the confusion matrix in csv format you'll have better demonstration."
 
 CLASSES_WARNING = "The class labels do not match used labels in actual and predict vectors.\n" \
-                  "Class labels are going to be assigned with {}"
+                  "Class labels are going to be assigned with {}."
 
 CLASS_NUMBER_THRESHOLD = 10
 

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -87,6 +87,8 @@ CLASS_NUMBER_WARNING = "The confusion matrix is a high dimension matrix and won'
 
 CLASSES_WARNING = "Used classes is not a subset of classes in actual and predict vectors."
 
+CLASSES_TYPE_WARNING = "The classes is neither a list nor None so it'll be ignored."
+
 CLASS_NUMBER_THRESHOLD = 10
 
 BALANCE_RATIO_THRESHOLD = 3

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -381,6 +381,8 @@ def classes_filter(actual_vector, predict_vector, classes=None):
         if not set(classes).issubset(classes_from_vectors):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes
+    elif classes is not None:
+        warn(CLASSES_TYPE_WARNING, RuntimeWarning)
     return [actual_vector, predict_vector, classes_list]
 
 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -335,6 +335,34 @@ def matrix_params_calc(
         actual_vector, predict_vector)
     if isinstance(sample_weight, numpy.ndarray):
         sample_weight = sample_weight.tolist()
+    [actual_vector, predict_vector, classes_list] = classes_filter(
+        actual_vector, predict_vector, classes)
+    map_dict = {k: 0 for k in classes_list}
+    table = {k: map_dict.copy() for k in classes_list}
+    weight_vector = [1] * len(actual_vector)
+    if isinstance(sample_weight, (list, numpy.ndarray)):
+        if len(sample_weight) == len(actual_vector):
+            weight_vector = sample_weight
+    for index, item in enumerate(actual_vector):
+        if item in classes_list and predict_vector[index] in classes_list:
+            table[item][predict_vector[index]] += 1 * weight_vector[index]
+    [_, _, TP_dict, TN_dict, FP_dict,
+        FN_dict] = matrix_params_from_table(table)
+    return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]
+
+
+def classes_filter(actual_vector, predict_vector, classes=None):
+    """
+    Return updated vectors and classes list.
+
+    :param actual_vector: actual values
+    :type actual_vector : list
+    :param predict_vector: predict value
+    :type predict_vector : list
+    :param classes: ordered labels of classes
+    :type classes: list
+    :return: [actual_vector, predict_vector, classes_list]
+    """
     classes_list = set(actual_vector).union(set(predict_vector))
     if len(classes_list) == 1:
         classes_list.add("~other~")
@@ -350,18 +378,7 @@ def matrix_params_calc(
         if not set(classes).issubset(classes_list):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes
-    map_dict = {k: 0 for k in classes_list}
-    table = {k: map_dict.copy() for k in classes_list}
-    weight_vector = [1] * len(actual_vector)
-    if isinstance(sample_weight, (list, numpy.ndarray)):
-        if len(sample_weight) == len(actual_vector):
-            weight_vector = sample_weight
-    for index, item in enumerate(actual_vector):
-        if item in classes_list and predict_vector[index] in classes_list:
-            table[item][predict_vector[index]] += 1 * weight_vector[index]
-    [_, _, TP_dict, TN_dict, FP_dict,
-        FN_dict] = matrix_params_from_table(table)
-    return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]
+    return [actual_vector, predict_vector, classes_list]
 
 
 def imbalance_check(P):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -374,7 +374,7 @@ def classes_filter(actual_vector, predict_vector, classes=None):
         classes_from_vectors = classes_list
         if isinstance(actual_vector[0], str) and not isinstance(classes[0], str):
             classes = list(map(str, classes))
-        elif isinstance(classes[0], str):
+        elif isinstance(classes[0], str) and not isinstance(actual_vector[0], str):
             actual_vector = list(map(str, actual_vector))
             predict_vector = list(map(str, predict_vector))
             classes_from_vectors = set(actual_vector).union(set(predict_vector))

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -331,8 +331,11 @@ def matrix_params_calc(
     :type classes: list
     :return: [classes_list,table,TP,TN,FP,FN]
     """
-    [actual_vector, predict_vector] = vector_filter(
+    [actual_vector_, predict_vector_] = vector_filter(
         actual_vector, predict_vector)
+    if actual_vector_ != actual_vector or predict_vector_ != predict_vector:
+        classes = [str(class_label) for class_label in classes]
+    actual_vector, predict_vector = actual_vector_, predict_vector_
     if isinstance(sample_weight, numpy.ndarray):
         sample_weight = sample_weight.tolist()
     classes_list = set(actual_vector).union(set(predict_vector))

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -331,35 +331,34 @@ def matrix_params_calc(
     :type classes: list
     :return: [classes_list,table,TP,TN,FP,FN]
     """
-    [actual_vector_, predict_vector_] = vector_filter(
+    [actual_vector, predict_vector] = vector_filter(
         actual_vector, predict_vector)
     if isinstance(sample_weight, numpy.ndarray):
         sample_weight = sample_weight.tolist()
-    classes_list = set(actual_vector_).union(set(predict_vector_))
+    classes_list = set(actual_vector).union(set(predict_vector))
     if len(classes_list) == 1:
         classes_list.add("~other~")
     classes_list = sorted(classes_list)
     if isinstance(classes, list):
-        classes_, _ = vector_filter(classes, [])
-        if classes != classes_:
-            actual_vector_ = [str(x) for x in actual_vector_]
-            predict_vector_ = [str(x) for x in predict_vector_]
-            classes_list = set(actual_vector_).union(set(predict_vector_))
-        classes = classes_
-        if actual_vector_ != actual_vector or predict_vector_ != predict_vector:
-            classes = [str(class_label) for class_label in classes]
+        classes, _ = vector_filter(classes, [])
+        if isinstance(actual_vector[0], str):
+            classes = [str(x) for x in classes]
+        if isinstance(classes[0], str):
+            actual_vector = [str(x) for x in actual_vector]
+            predict_vector = [str(x) for x in predict_vector]
+            classes_list = set(actual_vector).union(set(predict_vector))
         if not set(classes).issubset(classes_list):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes
     map_dict = {k: 0 for k in classes_list}
     table = {k: map_dict.copy() for k in classes_list}
-    weight_vector = [1] * len(actual_vector_)
+    weight_vector = [1] * len(actual_vector)
     if isinstance(sample_weight, (list, numpy.ndarray)):
-        if len(sample_weight) == len(actual_vector_):
+        if len(sample_weight) == len(actual_vector):
             weight_vector = sample_weight
-    for index, item in enumerate(actual_vector_):
-        if item in classes_list and predict_vector_[index] in classes_list:
-            table[item][predict_vector_[index]] += 1 * weight_vector[index]
+    for index, item in enumerate(actual_vector):
+        if item in classes_list and predict_vector[index] in classes_list:
+            table[item][predict_vector[index]] += 1 * weight_vector[index]
     [_, _, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
     return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -313,7 +313,11 @@ def matrix_params_from_table(table, transpose=False):
     return [classes, table_temp, TP_dict, TN_dict, FP_dict, FN_dict]
 
 
-def matrix_params_calc(actual_vector, predict_vector, sample_weight, classes):
+def matrix_params_calc(
+        actual_vector,
+        predict_vector,
+        sample_weight,
+        classes=None):
     """
     Calculate TP,TN,FP,FN for each class.
 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -368,6 +368,8 @@ def classes_filter(actual_vector, predict_vector, classes=None):
         classes_list.add("~other~")
     classes_list = sorted(classes_list)
     if isinstance(classes, list):
+        if len(classes) == 0:
+            return [actual_vector, predict_vector, classes]
         classes, _ = vector_filter(classes, [])
         classes_from_vectors = classes_list
         if isinstance(actual_vector[0], str):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -369,13 +369,14 @@ def classes_filter(actual_vector, predict_vector, classes=None):
     classes_list = sorted(classes_list)
     if isinstance(classes, list):
         classes, _ = vector_filter(classes, [])
+        classes_from_vectors = classes_list
         if isinstance(actual_vector[0], str):
             classes = list(map(str, classes))
         if isinstance(classes[0], str):
             actual_vector = list(map(str, actual_vector))
             predict_vector = list(map(str, predict_vector))
-            classes_list = set(actual_vector).union(set(predict_vector))
-        if not set(classes).issubset(classes_list):
+            classes_from_vectors = set(actual_vector).union(set(predict_vector))
+        if not set(classes).issubset(classes_from_vectors):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes
     return [actual_vector, predict_vector, classes_list]

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -333,28 +333,27 @@ def matrix_params_calc(
     """
     [actual_vector_, predict_vector_] = vector_filter(
         actual_vector, predict_vector)
-    if actual_vector_ != actual_vector or predict_vector_ != predict_vector:
-        classes = [str(class_label) for class_label in classes]
-    actual_vector, predict_vector = actual_vector_, predict_vector_
     if isinstance(sample_weight, numpy.ndarray):
         sample_weight = sample_weight.tolist()
-    classes_list = set(actual_vector).union(set(predict_vector))
+    classes_list = set(actual_vector_).union(set(predict_vector_))
     if len(classes_list) == 1:
         classes_list.add("~other~")
     classes_list = sorted(classes_list)
     if isinstance(classes, list):
+        if actual_vector_ != actual_vector or predict_vector_ != predict_vector:
+            classes = [str(class_label) for class_label in classes]
         if not set(classes).issubset(classes_list):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes
     map_dict = {k: 0 for k in classes_list}
     table = {k: map_dict.copy() for k in classes_list}
-    weight_vector = [1] * len(actual_vector)
+    weight_vector = [1] * len(actual_vector_)
     if isinstance(sample_weight, (list, numpy.ndarray)):
-        if len(sample_weight) == len(actual_vector):
+        if len(sample_weight) == len(actual_vector_):
             weight_vector = sample_weight
-    for index, item in enumerate(actual_vector):
-        if item in classes_list and predict_vector[index] in classes_list:
-            table[item][predict_vector[index]] += 1 * weight_vector[index]
+    for index, item in enumerate(actual_vector_):
+        if item in classes_list and predict_vector_[index] in classes_list:
+            table[item][predict_vector_[index]] += 1 * weight_vector[index]
     [_, _, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
     return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -347,7 +347,7 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight, classes):
             weight_vector = sample_weight
     for index, item in enumerate(actual_vector):
         table[item][predict_vector[index]] += 1 * weight_vector[index]
-    [classes_list, table, TP_dict, TN_dict, FP_dict,
+    [_, _, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
     return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]
 

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -340,6 +340,12 @@ def matrix_params_calc(
         classes_list.add("~other~")
     classes_list = sorted(classes_list)
     if isinstance(classes, list):
+        classes_, _ = vector_filter(classes, [])
+        if classes != classes_:
+            actual_vector_ = [str(x) for x in actual_vector_]
+            predict_vector_ = [str(x) for x in predict_vector_]
+            classes_list = set(actual_vector_).union(set(predict_vector_))
+        classes = classes_
         if actual_vector_ != actual_vector or predict_vector_ != predict_vector:
             classes = [str(class_label) for class_label in classes]
         if not set(classes).issubset(classes_list):

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -346,7 +346,8 @@ def matrix_params_calc(actual_vector, predict_vector, sample_weight, classes):
         if len(sample_weight) == len(actual_vector):
             weight_vector = sample_weight
     for index, item in enumerate(actual_vector):
-        table[item][predict_vector[index]] += 1 * weight_vector[index]
+        if item in classes_list and predict_vector[index] in classes_list:
+            table[item][predict_vector[index]] += 1 * weight_vector[index]
     [_, _, TP_dict, TN_dict, FP_dict,
         FN_dict] = matrix_params_from_table(table)
     return [classes_list, table, TP_dict, TN_dict, FP_dict, FN_dict]

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -372,9 +372,9 @@ def classes_filter(actual_vector, predict_vector, classes=None):
             return [actual_vector, predict_vector, classes]
         classes, _ = vector_filter(classes, [])
         classes_from_vectors = classes_list
-        if isinstance(actual_vector[0], str):
+        if isinstance(actual_vector[0], str) and not isinstance(classes[0], str):
             classes = list(map(str, classes))
-        if isinstance(classes[0], str):
+        elif isinstance(classes[0], str):
             actual_vector = list(map(str, actual_vector))
             predict_vector = list(map(str, predict_vector))
             classes_from_vectors = set(actual_vector).union(set(predict_vector))

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -342,10 +342,10 @@ def matrix_params_calc(
     if isinstance(classes, list):
         classes, _ = vector_filter(classes, [])
         if isinstance(actual_vector[0], str):
-            classes = [str(x) for x in classes]
+            classes = list(map(str, classes))
         if isinstance(classes[0], str):
-            actual_vector = [str(x) for x in actual_vector]
-            predict_vector = [str(x) for x in predict_vector]
+            actual_vector = list(map(str, actual_vector))
+            predict_vector = list(map(str, predict_vector))
             classes_list = set(actual_vector).union(set(predict_vector))
         if not set(classes).issubset(classes_list):
             warn(CLASSES_WARNING, RuntimeWarning)


### PR DESCRIPTION
#### Reference Issues/PRs
#358 

#### What does this implement/fix? Explain your changes.
+ `classes` optional parameter added to ConfusionMatrix, now you can use:
```
>>> y_act=[0,0,0,0,0,1,1,1,1,1,1,2,2,2,2]
>>> y_pre=[0,0,0,1,1,1,1,1,0,0,0,1,2,0,1]
>>> cm = ConfusionMatrix(y_act,y_pre,classes=[1,2,0])
>>> cm
pycm.ConfusionMatrix(classes: [1, 2, 0])
>>> cm.classes
[1, 2, 0]
>>> cm.to_array()
array([[3, 0, 3],
       [2, 1, 1],
       [2, 0, 3]])
>>> print(cm)
Predict 1       2       0       
Actual
1       3       0       3       

2       2       1       1       

0       2       0       3       
...
>>> cm = ConfusionMatrix(y_act,y_pre,classes=[1,2])
>>> cm
pycm.ConfusionMatrix(classes: [1, 2])
>>> cm.classes
[1, 2]
>>> cm.to_array()
array([[3, 0],
       [2, 1]])
>>> print(cm)
Predict 1       2       
Actual
1       3       0       

2       2       1       
...
>>> cm = ConfusionMatrix(y_act,y_pre,classes=[0,1,2,3])
/home/user/Programing/Git/pycm/pycm/pycm_util.py:340: RuntimeWarning: Used classes is not a subset of classes in actual and predict vectors.
  warn(CLASSES_WARNING, RuntimeWarning)
>>> cm
pycm.ConfusionMatrix(classes: [0, 1, 2, 3])
>>> cm.classes
[0, 1, 2, 3]
>>> cm.to_array()
array([[3, 2, 0, 0],
       [3, 3, 0, 0],
       [1, 2, 1, 0],
       [0, 0, 0, 0]])
>>> print(cm)
Predict 0       1       2       3       
Actual
0       3       2       0       0       

1       3       3       0       0       

2       1       2       1       0       

3       0       0       0       0       
...
```

