### PR TITLE
Is_imbalanced Added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `is_imbalanced` flag added to `__init__`
 ## [3.2] - 2021-08-11
 ### Added
 - `classes_filter` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- `is_imbalanced` flag added to `__init__`
+### Changed
+- `is_imbalanced` parameter added to ConfusionMatrix `__init__` method
 ## [3.2] - 2021-08-11
 ### Added
 - `classes_filter` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - `is_imbalanced` parameter added to ConfusionMatrix `__init__` method
+- `statistic_recommend` function modified
 ## [3.2] - 2021-08-11
 ### Added
 - `classes_filter` function

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -2204,6 +2204,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`is_imbalanced` parameter has been added in `version 3.3`, so the user can indicate whether the concerned dataset is imbalanced or not. As long as the user does not provide any information in this regard, the automatic detection algorithm will be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm4 = ConfusionMatrix(y_actu, y_pred, is_imbalanced = True)\n",
+    "cm4.imbalance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm4 = ConfusionMatrix(y_actu, y_pred, is_imbalanced = False)\n",
+    "cm4.imbalance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<ul>\n",
     "    <li><span style=\"color:red;\">Notice </span> :  also available in HTML report </li>\n",
     "</ul>"
@@ -2216,6 +2243,15 @@
     "<ul>\n",
     "    <li><span style=\"color:red;\">Notice </span> : The recommender system assumes that the input is the result of classification over the whole data rather than just a part of it. If the confusion matrix is the result of test data classification, the recommendation is not valid. </li>\n",
     "</ul>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<ul>\n",
+    "    <li><span style=\"color:red;\">Notice </span> :  `is_imbalanced` , new in <span style=\"color:red;\">version 3.3 </span> </li>\n",
+    "</ul>"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -650,6 +650,17 @@ False
 >>> cm.recommended_list
 ['MCC', 'TPR Micro', 'ACC', 'PPV Macro', 'BCD', 'Overall MCC', 'Hamming Loss', 'TPR Macro', 'Zero-one Loss', 'ERR', 'PPV Micro', 'Overall ACC']
 
+```
+
+`is_imbalanced` parameter has been added in `version 3.3`, so the user can indicate whether the concerned dataset is imbalanced or not. As long as the user does not provide any information in this regard, the automatic detection algorithm will be used.
+
+```pycon
+>>> cm = ConfusionMatrix(y_actu, y_pred, is_imbalanced = True)
+>>> cm.imbalance
+True
+>>> cm = ConfusionMatrix(y_actu, y_pred, is_imbalanced = False)
+>>> cm.imbalance
+False
 ```	
 
 ### Compare

--- a/Test/output_test.py
+++ b/Test/output_test.py
@@ -256,6 +256,8 @@ sInd(Similarity index)                                           None           
 >>> cm_no_vectors_file=ConfusionMatrix(file=open("test_no_vectors.obj","r"))
 >>> cm_stat_file==cm_file
 True
+>>> cm.imbalance == cm_file.imbalance
+True
 >>> cm_no_vectors_file==cm_file
 True
 >>> cm_no_vectors_dict = json.load(open("test_no_vectors.obj","r"))
@@ -488,11 +490,17 @@ True
 >>> cm_file.weights
 >>> cm_file.transpose
 False
+>>> cm_file.imbalance
+False
 >>> cm_file.matrix == {'1': {'1': 1, '2': 1, '0': 0}, '2': {'1': 2, '2': 3, '0': 0}, '0': {'1': 0, '2': 2, '0': 3}}
 True
 >>> cm_file.actual_vector == ['1', '1', '2', '2', '2', '2', '2', '0', '0', '0', '0', '0']
 True
 >>> cm_file.predict_vector == ['1', '2', '1', '1', '2', '2', '2', '2', '2', '0', '0', '0']
+True
+>>> json.dump({"Actual-Vector": ['1', '1', '2', '2', '2', '2', '2', '0', '0', '0', '0', '0'], "Digit": 5, "Predict-Vector": ['1', '2', '1', '1', '2', '2', '2', '2', '2', '0', '0', '0'], "Matrix": {"0": {"0": 3, "1": 0, "2": 2}, "1": {"0": 0, "1": 1, "2": 1}, "2": {"0": 0, "1": 2, "2": 3}}, "Is_imbalanced": True},open("test8.obj","w"))
+>>> cm_file=ConfusionMatrix(file=open("test8.obj","r"))
+>>> cm_file.imbalance
 True
 >>> cm_comp1 = ConfusionMatrix(matrix={0:{0:2,1:50,2:6},1:{0:5,1:50,2:3},2:{0:1,1:7,2:50}})
 >>> cm_comp2 = ConfusionMatrix(matrix={0:{0:50,1:2,2:6},1:{0:50,1:5,2:3},2:{0:1,1:55,2:2}})
@@ -560,6 +568,7 @@ True
 >>> os.remove("test5.obj")
 >>> os.remove("test6.obj")
 >>> os.remove("test7.obj")
+>>> os.remove("test8.obj")
 >>> os.remove("test.pycm")
 >>> os.remove("test.comp")
 >>> os.remove("test_header.csv")

--- a/Test/output_test.py
+++ b/Test/output_test.py
@@ -498,7 +498,7 @@ True
 True
 >>> cm_file.predict_vector == ['1', '2', '1', '1', '2', '2', '2', '2', '2', '0', '0', '0']
 True
->>> json.dump({"Actual-Vector": ['1', '1', '2', '2', '2', '2', '2', '0', '0', '0', '0', '0'], "Digit": 5, "Predict-Vector": ['1', '2', '1', '1', '2', '2', '2', '2', '2', '0', '0', '0'], "Matrix": {"0": {"0": 3, "1": 0, "2": 2}, "1": {"0": 0, "1": 1, "2": 1}, "2": {"0": 0, "1": 2, "2": 3}}, "Is_imbalanced": True},open("test8.obj","w"))
+>>> json.dump({"Actual-Vector": ['1', '1', '2', '2', '2', '2', '2', '0', '0', '0', '0', '0'], "Digit": 5, "Predict-Vector": ['1', '2', '1', '1', '2', '2', '2', '2', '2', '0', '0', '0'], "Matrix": {"0": {"0": 3, "1": 0, "2": 2}, "1": {"0": 0, "1": 1, "2": 1}, "2": {"0": 0, "1": 2, "2": 3}}, "Imbalanced": True},open("test8.obj","w"))
 >>> cm_file=ConfusionMatrix(file=open("test8.obj","r"))
 >>> cm_file.imbalance
 True

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1226,9 +1226,13 @@ True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=True)
 >>> cm.imbalance
 True
+>>> set(cm.recommended_list) == set(IMBALANCED_RECOMMEND)
+True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=False)
 >>> cm.imbalance
 False
+>>> set(cm.recommended_list) == set(BINARY_RECOMMEND)
+True
 >>> act = np.array([2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2])
 >>> pre = [0, 0, 2, 1, 0, 2, 1, 0, 2, 0, 2, 2]
 >>> cm = ConfusionMatrix(actual_vector=act, predict_vector=pre)

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1218,17 +1218,17 @@ True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True)
 >>> cm.imbalance
 False
+>>> set(cm.recommended_list) == set(BINARY_RECOMMEND)
+True
+>>> cm = ConfusionMatrix(matrix={1:{1:60,2:9,3:1,4:0,5:0,6:0},2:{1:23,2:48,3:0,4:2,5:2,6:1},3:{1:11,2:5,3:60,4:0,5:0,6:0},4:{1:0,2:2,3:0,4:60,5:1,6:3},5:{1:2,2:1,3:0,4:0,5:60,6:2},6:{1:1,2:2,3:0,4:2,5:1,6:60}})
+>>> set(cm.recommended_list) == set(MULTICLASS_RECOMMEND)
+True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=True)
 >>> cm.imbalance
 True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=False)
 >>> cm.imbalance
 False
->>> set(cm.recommended_list) == set(BINARY_RECOMMEND)
-True
->>> cm = ConfusionMatrix(matrix={1:{1:60,2:9,3:1,4:0,5:0,6:0},2:{1:23,2:48,3:0,4:2,5:2,6:1},3:{1:11,2:5,3:60,4:0,5:0,6:0},4:{1:0,2:2,3:0,4:60,5:1,6:3},5:{1:2,2:1,3:0,4:0,5:60,6:2},6:{1:1,2:2,3:0,4:2,5:1,6:60}})
->>> set(cm.recommended_list) == set(MULTICLASS_RECOMMEND)
-True
 >>> act = np.array([2, 0, 2, 2, 0, 1, 1, 2, 2, 0, 1, 2])
 >>> pre = [0, 0, 2, 1, 0, 2, 1, 0, 2, 0, 2, 2]
 >>> cm = ConfusionMatrix(actual_vector=act, predict_vector=pre)

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1218,6 +1218,12 @@ True
 >>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True)
 >>> cm.imbalance
 False
+>>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=True)
+>>> cm.imbalance
+True
+>>> cm = ConfusionMatrix(matrix={1:{1:295593,2:30516},2:{1:5108,2:295593}},transpose=True,is_imbalanced=False)
+>>> cm.imbalance
+False
 >>> set(cm.recommended_list) == set(BINARY_RECOMMEND)
 True
 >>> cm = ConfusionMatrix(matrix={1:{1:60,2:9,3:1,4:0,5:0,6:0},2:{1:23,2:48,3:0,4:2,5:2,6:1},3:{1:11,2:5,3:60,4:0,5:0,6:0},4:{1:0,2:2,3:0,4:60,5:1,6:3},5:{1:2,2:1,3:0,4:0,5:60,6:2},6:{1:1,2:2,3:0,4:2,5:1,6:60}})

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -238,7 +238,7 @@ def __obj_file_handler__(cm, file):
         matrix_param = matrix_params_from_table(loaded_matrix)
     cm.digit = obj_data["Digit"]
     try:
-        cm.imbalance = obj_data["Is_imbalanced"]
+        cm.imbalance = obj_data["Imbalanced"]
     except Exception:
         cm.imbalance = None
 

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -237,6 +237,10 @@ def __obj_file_handler__(cm, file):
             loaded_matrix[i] = dict(loaded_matrix[i])
         matrix_param = matrix_params_from_table(loaded_matrix)
     cm.digit = obj_data["Digit"]
+    try:
+        cm.imbalance = obj_data["Is_imbalanced"]
+    except Exception:
+        cm.imbalance = None
 
     return matrix_param
 

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -69,6 +69,7 @@ class ConfusionMatrix():
         self.digit = digit
         self.weights = None
         self.classes = None
+        self.imbalance = None
         if isinstance(transpose, bool):
             self.transpose = transpose
         else:
@@ -85,9 +86,10 @@ class ConfusionMatrix():
         __obj_assign_handler__(self, matrix_param)
         __class_stat_init__(self)
         __overall_stat_init__(self)
-        if is_imbalanced is None:
-            is_imbalanced = imbalance_check(self.P)
-        self.imbalance = is_imbalanced
+        if self.imbalance is None:
+            if is_imbalanced is None:
+                is_imbalanced = imbalance_check(self.P)
+            self.imbalance = is_imbalanced
         self.binary = binary_check(self.classes)
         self.recommended_list = statistic_recommend(self.classes, self.P)
         self.sparse_matrix = None
@@ -471,7 +473,8 @@ class ConfusionMatrix():
                          "Matrix": matrix_items,
                          "Digit": self.digit,
                          "Sample-Weight": weights_vector_temp,
-                         "Transpose": self.transpose}
+                         "Transpose": self.transpose,
+                         "Is_imbalanced": self.imbalance}
             if save_stat:
                 dump_dict["Class-Stat"] = self.class_stat
                 dump_dict["Overall-Stat"] = self.overall_stat

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -39,7 +39,7 @@ class ConfusionMatrix():
             matrix=None,
             digit=5, threshold=None, file=None,
             sample_weight=None, transpose=False,
-            classes=None):
+            classes=None, is_imbalanced=None):
         """
         Init method.
 
@@ -61,6 +61,8 @@ class ConfusionMatrix():
         :type transpose : bool
         :param classes: ordered labels of classes
         :type classes: list
+        :param is_imbalanced: imbalance dataset flag
+        :type is_imbalanced: bool
         """
         self.actual_vector = actual_vector
         self.predict_vector = predict_vector
@@ -83,7 +85,9 @@ class ConfusionMatrix():
         __obj_assign_handler__(self, matrix_param)
         __class_stat_init__(self)
         __overall_stat_init__(self)
-        self.imbalance = imbalance_check(self.P)
+        if is_imbalanced is None:
+            is_imbalanced = imbalance_check(self.P)
+        self.imbalance = is_imbalanced
         self.binary = binary_check(self.classes)
         self.recommended_list = statistic_recommend(self.classes, self.P)
         self.sparse_matrix = None

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -91,7 +91,7 @@ class ConfusionMatrix():
                 is_imbalanced = imbalance_check(self.P)
             self.imbalance = is_imbalanced
         self.binary = binary_check(self.classes)
-        self.recommended_list = statistic_recommend(self.classes, self.P)
+        self.recommended_list = statistic_recommend(self.classes, self.imbalance)
         self.sparse_matrix = None
         self.sparse_normalized_matrix = None
         self.positions = None

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -474,7 +474,7 @@ class ConfusionMatrix():
                          "Digit": self.digit,
                          "Sample-Weight": weights_vector_temp,
                          "Transpose": self.transpose,
-                         "Is_imbalanced": self.imbalance}
+                         "Imbalanced": self.imbalance}
             if save_stat:
                 dump_dict["Class-Stat"] = self.class_stat
                 dump_dict["Overall-Stat"] = self.overall_stat

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -372,12 +372,17 @@ def classes_filter(actual_vector, predict_vector, classes=None):
             return [actual_vector, predict_vector, classes]
         classes, _ = vector_filter(classes, [])
         classes_from_vectors = classes_list
-        if isinstance(actual_vector[0], str) and not isinstance(classes[0], str):
+        if isinstance(
+                actual_vector[0],
+                str) and not isinstance(
+                classes[0],
+                str):
             classes = list(map(str, classes))
         elif isinstance(classes[0], str) and not isinstance(actual_vector[0], str):
             actual_vector = list(map(str, actual_vector))
             predict_vector = list(map(str, predict_vector))
-            classes_from_vectors = set(actual_vector).union(set(predict_vector))
+            classes_from_vectors = set(
+                actual_vector).union(set(predict_vector))
         if not set(classes).issubset(classes_from_vectors):
             warn(CLASSES_WARNING, RuntimeWarning)
         classes_list = classes

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -441,17 +441,17 @@ def complement(input_number):
         return "None"
 
 
-def statistic_recommend(classes, P):
+def statistic_recommend(classes, imbalance):
     """
     Return recommend parameters which are more suitable due to the input dataset characteristics.
 
     :param classes:  all classes name
     :type classes : list
-    :param P: condition positive
-    :type P : dict
+    :param imbalance : imbalance flag
+    :type imbalance : bool
     :return: recommendation_list as list
     """
-    if imbalance_check(P):
+    if imbalance:
         return IMBALANCED_RECOMMEND
     if binary_check(classes):
         return BINARY_RECOMMEND


### PR DESCRIPTION
#### Reference Issues/PRs
#276 
#### What does this implement/fix? Explain your changes.
In this PR `is_imbalanced` added to `__init__` as a flag which can control the imbalance of datasets from client side.
If this flag is set to `True` or `False` checking the imbalance of datasets won't be done and the `self.imbalance` will be assigned to `is_imbalanced`.

As @sepandhaghighi mentioned it's better to save the inherit imbalance of confusion matrix when saving as `.obj` file and then reading it when loading confusion matrix as `.obj` file in a backward compatible manner in which older PyCM output versions would be supported too.
