### PR TITLE
Doc str

### DIFF
--- a/pycm/pycm_class_func.py
+++ b/pycm/pycm_class_func.py
@@ -195,7 +195,7 @@ def TTPN_calc(item1, item2):
 
 def FXR_calc(item):
     """
-    Calculate False negative rate (FNR), False positive rate (FPR), False discovery rate (FDR), and False omission rate (FOR).
+    Calculate False negative rate, False positive rate, False discovery rate (FDR), and False omission rate (FOR).
 
     :param item: item In expression
     :type item:float

--- a/pycm/pycm_compare.py
+++ b/pycm/pycm_compare.py
@@ -44,7 +44,7 @@ class Compare():
         """
         Init method.
 
-        :param cm_dict: input confusion matrix
+        :param cm_dict: dictionary of confusion matrices
         :type cm_dict: dict
         :param by_class: compare by class flag
         :type by_class: bool
@@ -149,7 +149,7 @@ def __compare_class_handler__(compare, cm_dict):
 
     :param compare: Compare
     :type compare: pycm.Compare object
-    :param cm_dict: input confusion matrix
+    :param cm_dict: dictionary of confusion matrices
     :type cm_dict: dict
     :return: None
     """
@@ -175,7 +175,7 @@ def __compare_overall_handler__(compare, cm_dict):
 
     :param compare: Compare
     :type compare: pycm.Compare object
-    :param cm_dict: input confusion matrix
+    :param cm_dict: dictionary of confusion matrices
     :type cm_dict: dict
     :return: None
     """
@@ -200,7 +200,7 @@ def __compare_rounder__(compare, cm_dict):
 
     :param compare: Compare
     :type compare: pycm.Compare object
-    :param cm_dict: input confusion matrix
+    :param cm_dict: dictionary of confusion matrices
     :type cm_dict: dict
     :return: None
     """
@@ -289,7 +289,7 @@ def __compare_assign_handler__(
 
     :param compare: Compare
     :type compare: pycm.Compare object
-    :param cm_dict: input confusion matrix
+    :param cm_dict: dictionary of confusion matrices
     :type cm_dict: dict
     :param class_weight: class weights
     :type class_weight: dict

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -244,7 +244,7 @@ def __obj_matrix_handler__(matrix, transpose):
     """
     Handle object conditions for the matrix.
 
-    :param matrix: direct matrix
+    :param matrix: the confusion matrix in dict form
     :type matrix: dict
     :param transpose: transpose flag
     :type transpose: bool

--- a/pycm/pycm_handler.py
+++ b/pycm/pycm_handler.py
@@ -274,7 +274,7 @@ def __obj_vector_handler__(
     :type cm: pycm.ConfusionMatrix object
     :param actual_vector: actual vector
     :type actual_vector: python list or numpy array of any stringable objects
-    :param predict_vector: predicted vector
+    :param predict_vector: vector of predictions
     :type predict_vector: python list or numpy array of any stringable objects
     :param threshold: activation threshold function
     :type threshold: FunctionType (function or lambda)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -171,7 +171,7 @@ class ConfusionMatrix():
         :type overall_param: list
         :param class_param: class parameters list for print, Example: ["TPR", "TNR", "AUC"]
         :type class_param: list
-        :param class_name: class name (a subset of classes names), Example: [1, 2, 3]
+        :param class_name: class name (a subset of confusion matrix classes), Example: [1, 2, 3]
         :type class_name: list
         :param summary: summary mode flag
         :type summary: bool

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -49,7 +49,7 @@ class ConfusionMatrix():
         :type predict_vector: python list or numpy array of any stringable objects
         :param matrix: directly imported confusion matrix
         :type matrix: dict
-        :param digit: precision digit (default value: 5)
+        :param digit: scale (number of fraction digits)(default value: 5)
         :type digit: int
         :param threshold: activation threshold function
         :type threshold: FunctionType (function or lambda)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -45,7 +45,7 @@ class ConfusionMatrix():
 
         :param actual_vector: actual vector
         :type actual_vector: python list or numpy array of any stringable objects
-        :param predict_vector: predicted vector
+        :param predict_vector: vector of predictions
         :type predict_vector: python list or numpy array of any stringable objects
         :param matrix: directly imported confusion matrix
         :type matrix: dict

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -386,7 +386,7 @@ class ConfusionMatrix():
             summary=False,
             header=False):
         """
-        Save ConfusionMatrix in CSV file.
+        Save ConfusionMatrix in csv file.
 
         :param name: filename
         :type name: str
@@ -402,7 +402,7 @@ class ConfusionMatrix():
         :type normalize: bool
         :param summary: summary mode flag
         :type summary: bool
-        :param header: add headers to .csv file
+        :param header: add headers to csv file
         :type header: bool
         :return: saving address as dict {"Status":bool, "Message":str}
         """

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -47,7 +47,7 @@ class ConfusionMatrix():
         :type actual_vector: python list or numpy array of any stringable objects
         :param predict_vector: vector of predictions
         :type predict_vector: python list or numpy array of any stringable objects
-        :param matrix: directly imported confusion matrix
+        :param matrix: the confusion matrix in dict form
         :type matrix: dict
         :param digit: scale (number of fraction digits)(default value: 5)
         :type digit: int

--- a/pycm/pycm_output.py
+++ b/pycm/pycm_output.py
@@ -155,7 +155,7 @@ def html_overall_stat(
 
     :param overall_stat: overall stats
     :type overall_stat: dict
-    :param digit: scale (number of fraction digits)
+    :param digit: scale (number of fraction digits)(default value: 5)
     :type digit: int
     :param overall_param: overall parameters list for print, Example: ["Kappa", "Scott PI"]
     :type overall_param: list
@@ -210,7 +210,7 @@ def html_class_stat(
     :type classes: list
     :param class_stat: class stat
     :type class_stat:dict
-    :param digit: scale (number of fraction digits)
+    :param digit: scale (number of fraction digits)(default value: 5)
     :type digit: int
     :param class_param: class parameters list for print, Example: ["TPR", "TNR", "AUC"]
     :type class_param: list
@@ -374,7 +374,7 @@ def csv_print(classes, class_stat, digit=5, class_param=None):
     :type classes: list
     :param class_stat: statistic result for each class
     :type class_stat:dict
-    :param digit: scale (number of fraction digits)
+    :param digit: scale (number of fraction digits)(default value: 5)
     :type digit: int
     :param class_param: class parameters list for print, Example: ["TPR", "TNR", "AUC"]
     :type class_param: list
@@ -413,7 +413,7 @@ def stat_print(
     :type class_stat: dict
     :param overall_stat: overall statistic result
     :type overall_stat:dict
-    :param digit: scale (number of fraction digits)
+    :param digit: scale (number of fraction digits)(default value: 5)
     :type digit: int
     :param overall_param: overall parameters list for print, Example: ["Kappa", "Scott PI"]
     :type overall_param: list

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -492,7 +492,7 @@ def add_number_label(ax, classes, matrix, cmap, plot_lib):
     :type ax: matplotlib.axes
     :param classes: confusion matrix classes
     :type classes: list
-    :param matrix: derived matrix of confusion matrix
+    :param matrix: the confusion matrix in array form
     :type matrix: numpy.array
     :param cmap: color map
     :type cmap: matplotlib.colors.ListedColormap
@@ -534,7 +534,7 @@ def axes_gen(
     :type ax: matplotlib.axes
     :param classes: confusion matrix classes
     :type classes: list
-    :param matrix: derived matrix of confusion matrix
+    :param matrix: the confusion matrix in array form
     :type matrix: numpy.array
     :param title: plot title
     :type title: str

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -40,7 +40,7 @@ def rounder(input_number, digit=5):
 
     :param input_number: input number
     :type input_number: anything
-    :param digit: scale (number of fraction digits)
+    :param digit: scale (number of fraction digits)(default value: 5)
     :type digit: int
     :return: round number as str
     """

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -118,7 +118,7 @@ def vector_filter(actual_vector, predict_vector):
 
     :param actual_vector: actual values
     :type actual_vector: list
-    :param predict_vector: predict values
+    :param predict_vector: vector of predictions
     :type predict_vector: list
     :return: new actual and predict vectors
     """
@@ -323,7 +323,7 @@ def matrix_params_calc(
 
     :param actual_vector: actual values
     :type actual_vector: list
-    :param predict_vector: predict values
+    :param predict_vector: vector of predictions
     :type predict_vector: list
     :param sample_weight: sample weights list
     :type sample_weight: list
@@ -357,7 +357,7 @@ def classes_filter(actual_vector, predict_vector, classes=None):
 
     :param actual_vector: actual values
     :type actual_vector: list
-    :param predict_vector: predict values
+    :param predict_vector: vector of predictions
     :type predict_vector: list
     :param classes: ordered labels of classes
     :type classes: list


### PR DESCRIPTION
#### Reference Issues/PRs
#345 

#### What does this implement/fix? Explain your changes.

1. `FXR_calc` function description has been shortened.
2. `:param class_name: class name (a subset of classes names)` rewritten as `:param class_name: class name (a subset of confusion matrix classes)`
3. Unify the description of `:param digit`
4. Correct the description of `:param cm_dict:` in `pycm_compare.py` 
5. Unify mentioning csv 
6. Unify the description of `predict_vector`
7. Unify the description of `:param matrix`

#### Any other comments

@sepandhaghighi @sadrasabouri Please double-check everything, especially the consistency and correctness of the descriptions. Thanks!