### PR TITLE
fix for issue #430 decimal

### DIFF
--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -154,7 +154,9 @@ class ConfusionMatrix():
                     classes, normalized_table)
             print(sparse_table_print(self.sparse_normalized_matrix))
         else:
-            print(table_print(classes, normalized_table))
+            # Band aid for #430 :- using a dictionary  comprehension to round the values of normalized_table
+            normalized_table_ = {outer_k: {inner_k: round(inner_v,self.digit) for inner_k, inner_v in outer_v.items()} for outer_k, outer_v in normalized_table.items()}
+            print(table_print(classes, normalized_table_))
         if len(classes) >= CLASS_NUMBER_THRESHOLD:
             warn(CLASS_NUMBER_WARNING, RuntimeWarning)
 


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/sepandhaghighi/pycm/issues/430

#### What does this implement/fix? Explain your changes.
This will help to control the decimal points in the output screen. It locally rounds up the dictionary values when `print_normalized_matrix` method is called

#### Any other comments?
Although it passes the test. My own recommendation would be to round the numbers at the source. I tried to round up the figures at `normalized_table_cal` method but it was causing some unknown issue. So I didn't proceed that way and found this temp fix.
