### PR TITLE
Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,22 +43,22 @@ jobs:
     - name: Version check
       run: |
         python Otherfiles/version_check.py
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.8
     - name: Notebook check
       run: |
         pip install notebook>=5.2.2
         python Otherfiles/notebook_check.py
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
     - name: Other tests
       run: |
           python -m vulture pycm/ Otherfiles/ setup.py --min-confidence 65 --exclude=__init__.py --sort-by-size
           python -m bandit -r pycm -s B311
           python -m pydocstyle -v --match-dir=pycm
-      if: matrix.python-version == 3.7
+      if: matrix.python-version == 3.8
     - name: Codecov
       run: |
         codecov
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
     - name: cProfile
       run: |
           python -m cProfile -s cumtime pycm/pycm_profile.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `CONTRIBUTING.md` updated
 - `matrix_params_calc` function optimized
 - `README.md` modified
+- Test system modified
 ## [3.6] - 2022-08-17
 ### Added
 - Hamming distance


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- Test system modified

#### Any other comments?
`importlib-metadata` released `v5.0.0` yesterday which removed the deprecated endpoint and didn't support `Python 3.7`([Failed Job](https://github.com/sepandhaghighi/pycm/actions/runs/3211997196/jobs/5250548090)). So it would be better to upgrade the Python version for specific tests.
https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean
