### PR TITLE
Relabel Bug Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	29. Consonni & Todeschini IV
 	30. Consonni & Todeschini V
 ### Changed
+- `relabel` method functionality
 - `README.md` modified
 - Document modified
 - Test system modified

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1443,7 +1443,28 @@ pycm.ConfusionMatrix(classes: ['1', '~other~'])
 >>> actual = [1,0,0,0,1,2,0,2,1]
 >>> predict = [1,0,1,1,1,2,0,2,0]
 >>> cm = ConfusionMatrix(actual,predict)
->>> cm.relabel({0:1,1:2,2:3})
+>>> cm.print_matrix()
+Predict 0       1       2
+Actual
+0       2       2       0
+<BLANKLINE>
+1       1       2       0
+<BLANKLINE>
+2       0       0       2
+<BLANKLINE>
+<BLANKLINE>
+>>> cm.relabel({0:"Z", 1:"A", 2:"B"})
+>>> cm.print_matrix()
+Predict Z       A       B
+Actual
+Z       2       2       0
+<BLANKLINE>
+A       1       2       0
+<BLANKLINE>
+B       0       0       2
+<BLANKLINE>
+<BLANKLINE>
+>>> cm.relabel({"Z":1, "A":2, "B":3})
 >>> cm
 pycm.ConfusionMatrix(classes: [1, 2, 3])
 >>> cm.label_map[0]

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -768,7 +768,7 @@ class ConfusionMatrix():
             temp_label_map[prime_label] = mapping[new_label]
         self.label_map = temp_label_map
         self.positions = None
-        self.classes = list(mapping.values())
+        self.classes = [mapping[x] for x in self.classes]
         self.TP = self.class_stat["TP"]
         self.TN = self.class_stat["TN"]
         self.FP = self.class_stat["FP"]

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -768,7 +768,7 @@ class ConfusionMatrix():
             temp_label_map[prime_label] = mapping[new_label]
         self.label_map = temp_label_map
         self.positions = None
-        self.classes = sorted(list(mapping.values()))
+        self.classes = list(mapping.values())
         self.TP = self.class_stat["TP"]
         self.TN = self.class_stat["TN"]
         self.FP = self.class_stat["FP"]


### PR DESCRIPTION
#### Reference Issues/PRs
There was a bug in the `relabel` method which was as below:
```python
>>> from pycm import *
>>> cm = ConfusionMatrix([1,1,1,0],[0,1,1,0],classes=[0,1])
>>> cm.print_matrix()
Predict 0       1       
Actual
0       1       0       

1       1       2       


>>> cm.classes
[0, 1]
>>> cm.relabel({0:"Z",1:"A"})
>>> cm.classes
['A', 'Z']
>>> cm.print_matrix()
Predict A       Z       
Actual
A       2       1       

Z       0       1       


```
This is while we inherently expect relabeling to keep the order.

#### What does this implement/fix? Explain your changes.
In this PR I solved the bug simply by keeping the `cm.classes`'s order after relabeling. Now we have the below results:
```python
>>> from pycm import *
>>> cm = ConfusionMatrix([1,1,1,0],[0,1,1,0],classes=[0,1])
>>> cm.print_matrix()
Predict 0       1       
Actual
0       1       0       

1       1       2       


>>> cm.classes
[0, 1]
>>> cm.relabel({0:"Z",1:"A"})
>>> cm.classes
['Z', 'A']
>>> cm.print_matrix()
Predict Z       A       
Actual
Z       1       0       

A       1       2       


```