### PR TITLE
Add `sort` parameter to `relabel` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- `sort` parameter added to `relabel` method
 - Document modified
 ## [3.8] - 2023-02-01
 ### Added

--- a/Document/Document.ipynb
+++ b/Document/Document.ipynb
@@ -1850,7 +1850,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cm.relabel(mapping={0:\"L1\",1:\"L2\",2:\"L3\"})"
+    "cm.relabel(mapping={0:\"L1\",1:\"L2\",2:\"L3\"}, sort=True)"
    ]
   },
   {
@@ -1884,7 +1884,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. `mapping` : mapping dictionary (type : `dict`)"
+    "1. `mapping` : mapping dictionary (type : `dict`)\n",
+    "2. `sort` : flag for sorting new classes (type : `bool`, default : `False`)"
    ]
   },
   {
@@ -1893,6 +1894,15 @@
    "source": [
     "<ul>\n",
     "    <li><span style=\"color:red;\">Notice </span> :  new in <span style=\"color:red;\">version 1.5</span> </li>\n",
+    "</ul>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<ul>\n",
+    "    <li><span style=\"color:red;\">Notice </span> : `sort` added in <span style=\"color:red;\">version 3.9</span></li>\n",
     "</ul>"
    ]
   },

--- a/Test/overall_test.py
+++ b/Test/overall_test.py
@@ -1454,6 +1454,8 @@ Actual
 <BLANKLINE>
 <BLANKLINE>
 >>> cm.relabel({0:"Z", 1:"A", 2:"B"})
+>>> cm
+pycm.ConfusionMatrix(classes: ['Z', 'A', 'B'])
 >>> cm.print_matrix()
 Predict Z       A       B
 Actual
@@ -1473,6 +1475,19 @@ pycm.ConfusionMatrix(classes: [1, 2, 3])
 2
 >>> cm.label_map[2]
 3
+>>> cm.relabel({1:3, 2:2, 3:1}, sort=True)
+>>> cm
+pycm.ConfusionMatrix(classes: [1, 2, 3])
+>>> cm.print_matrix()
+Predict 1       2       3
+Actual
+1       2       0       0
+<BLANKLINE>
+2       0       2       1
+<BLANKLINE>
+3       0       2       2
+<BLANKLINE>
+<BLANKLINE>
 >>> y_act = [0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2]
 >>> y_pre = [0,0,0,0,0,0,0,0,0,1,1,1,0,0,0,1,1,1,1,1,2,0,1,2,2,2,2]
 >>> cm = ConfusionMatrix(y_act,y_pre)

--- a/pycm/pycm_obj.py
+++ b/pycm/pycm_obj.py
@@ -728,12 +728,14 @@ class ConfusionMatrix():
         """
         return self.__copy__()
 
-    def relabel(self, mapping):
+    def relabel(self, mapping, sort=False):
         """
         Rename the confusion matrix classes.
 
         :param mapping: mapping dictionary
         :type mapping: dict
+        :param sort: flag for sorting new classes
+        :type sort: bool
         :return: None
         """
         if not isinstance(mapping, dict):
@@ -769,6 +771,8 @@ class ConfusionMatrix():
         self.label_map = temp_label_map
         self.positions = None
         self.classes = [mapping[x] for x in self.classes]
+        if sort:
+            self.classes = sorted(self.classes)
         self.TP = self.class_stat["TP"]
         self.TN = self.class_stat["TN"]
         self.FP = self.class_stat["FP"]


### PR DESCRIPTION
#### Reference Issues/PRs
#412 

#### What does this implement/fix? Explain your changes.
We now have a `sort` parameter for the `relabel` method which can be used in the case when the user wanted to sort the relabeled classes instead of keeping the same order.
