### PR TITLE
Deprecation Decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `deprecated` function
 ### Changed
 - Test system modified
 - Python 3.5 support dropped

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -568,6 +568,6 @@ pycm.PRCurve(classes: [2, 1])
 >>> @deprecated
 ... def test_deprecated():
 ...    return
->>> with warns(DeprecationWarning, match='`test_deprecated` function is deprecated and may be removed in future releases.'):
+>>> with warns(DeprecationWarning, match='`test_deprecated` is deprecated and may be removed in future releases.'):
 ...    test_deprecated()
 """

--- a/Test/warning_test.py
+++ b/Test/warning_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 >>> from pycm import *
+>>> from pycm.pycm_util import deprecated
 >>> from pytest import warns
 >>> large_cm = ConfusionMatrix(list(range(10)) + [2, 3, 5], list(range(10)) + [1, 7, 2])
 >>> with warns(RuntimeWarning, match='The confusion matrix is a high dimension matrix'):
@@ -564,4 +565,9 @@ pycm.ConfusionMatrix(classes: [1, 2])
 ...     crv = PRCurve(actual_vector=[1, 1, 2, 2], probs=[[0.1, 0.9], [0.4, 0.6], [0.35, 0.65], [0.8, 0.2]], classes=[2, 1])
 >>> crv
 pycm.PRCurve(classes: [2, 1])
+>>> @deprecated
+... def test_deprecated():
+...    return
+>>> with warns(DeprecationWarning, match='`test_deprecated` function is deprecated and may be removed in future releases.'):
+...    test_deprecated()
 """

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -120,7 +120,7 @@ CLASSES_TYPE_WARNING = "The classes is neither a list nor None so it'll be ignor
 
 CURVE_NONE_WARNING = "The curve axes contain non-numerical value(s)."
 
-DEPRECATION_WARNING = "`{}` function is deprecated and may be removed in future releases."
+DEPRECATION_WARNING = "`{}` is deprecated and may be removed in future releases."
 
 DISTANCE_METRIC_TYPE_ERROR = "The metric type must be DistanceType"
 

--- a/pycm/pycm_param.py
+++ b/pycm/pycm_param.py
@@ -120,6 +120,8 @@ CLASSES_TYPE_WARNING = "The classes is neither a list nor None so it'll be ignor
 
 CURVE_NONE_WARNING = "The curve axes contain non-numerical value(s)."
 
+DEPRECATION_WARNING = "`{}` function is deprecated and may be removed in future releases."
+
 DISTANCE_METRIC_TYPE_ERROR = "The metric type must be DistanceType"
 
 CLASS_NUMBER_THRESHOLD = 10

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -781,3 +781,31 @@ def metrics_off_check(func):
             raise pycmMatrixError(METRICS_OFF_ERROR)
         return func(*args, **kwargs)
     return inner_function
+
+
+def deprecated(func):
+    """
+    Send a warning for decorated function's deprication while using it.
+
+    :param func: input function
+    :type func: function
+    :return: inner function
+    """
+    @wraps(func)
+    def inner_function(*args, **kwargs):
+        """
+        Inner function.
+
+        :param args: non-keyword arguments
+        :type args: list
+        :param kwargs: keyword arguments
+        :type kwargs: dict
+        :return: None
+        """
+        warn(
+            DEPRECATION_WARNING.format(
+                func.__name__),
+            category=DeprecationWarning,
+            stacklevel=2)
+        return func(*args, **kwargs)
+    return inner_function

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -775,7 +775,7 @@ def metrics_off_check(func):
         :type args: list
         :param kwargs: keyword arguments
         :type kwargs: dict
-        :return: None
+        :return: modified function result
         """
         if args[0].metrics_off:
             raise pycmMatrixError(METRICS_OFF_ERROR)
@@ -785,7 +785,7 @@ def metrics_off_check(func):
 
 def deprecated(func):
     """
-    Send a warning regarding decorated function's deprication.
+    Send a warning regarding decorated function's deprecation.
 
     :param func: input function
     :type func: function
@@ -800,7 +800,7 @@ def deprecated(func):
         :type args: list
         :param kwargs: keyword arguments
         :type kwargs: dict
-        :return: None
+        :return: modified function result
         """
         warn(
             DEPRECATION_WARNING.format(

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -785,7 +785,7 @@ def metrics_off_check(func):
 
 def deprecated(func):
     """
-    Send a warning regarding decorated function's deprecation.
+    Send a warning regarding function's deprecation.
 
     :param func: input function
     :type func: function

--- a/pycm/pycm_util.py
+++ b/pycm/pycm_util.py
@@ -785,7 +785,7 @@ def metrics_off_check(func):
 
 def deprecated(func):
     """
-    Send a warning for decorated function's deprication while using it.
+    Send a warning regarding decorated function's deprication.
 
     :param func: input function
     :type func: function


### PR DESCRIPTION
#### Reference Issues/PRs
#499 
#### What does this implement/fix? Explain your changes.
You can now use a `deprecated` decorator for those functions which will be removed in future releases to warn users to change their use-cases. It may need more complex structures like function suggestion mapping, etc., which look far from this PR's scope. To wrap up the change is:
- `deprecated` function

#### Any other comments?
I tested it locally for `__len__`method and it works fine:
```python
from pycm import ConfusionMatrix
cm  = ConfusionMatrix([0, 1, 0, 1], [1, 1, 1, 1])
len(cm)
```
```
/home/sadra/local/pycm/tmp.py:3: DeprecationWarning: `__len__` function is deprecated and may be removed in future releases.
  len(cm)
```