### PR TITLE
Test System

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0, 3.11.0]
+        python-version: [3.6, 3.7.9, 3.8, 3.9, 3.10.0, 3.11.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       if: matrix.python-version == env.TEST_PYTHON_VERSION && matrix.os == env.TEST_OS
     - name: cProfile
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macOS-latest]
+        os: [ubuntu-20.04, windows-2022, macOS-12]
         python-version: [3.6, 3.7.9, 3.8, 3.9, 3.10.0, 3.11.0]
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Document modified
 - `README.md` modified
+- Test system modified
 ## [4.0] - 2023-06-07
 ### Added
 - `pycmMultiLabelError` class


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- Test system modified
- `fail_ci_if_error` flag --> `false`
- `macOS` version --> 12
- `windows` version --> 2022
- `Python 3.7` --> `Python 3.7.9`

#### Any other comments?
One of the new releases of `Python 3.7` (`Python 3.7.17`) has a very strange issue with `seaborn` importing in `macOS`!

![image](https://github.com/sepandhaghighi/pycm/assets/7515099/bf5aca33-cf2c-45a4-b40f-9e97c7b13603)



