### PR TITLE
Issue template problem

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,11 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your time to fill out this bug report!
+        Thanks for taking the time to fill out this bug report!
   - type: input
     id: contact
     attributes:
-      label: Contact details
+      label: Contact Details
       description: How can we get in touch with you if we need more info?
       placeholder: ex. email@example.com
     validations:
@@ -19,7 +19,6 @@ body:
     attributes:
       label: What happened?
       description: Provide a clear and concise description of what the bug is.
-      placeholder: Tell us a description of the bug.
     validations:
       required: true
   - type: textarea
@@ -27,30 +26,27 @@ body:
     attributes:
       label: Steps to reproduce
       description: Provide details of how to reproduce the bug.
-      placeholder: ex. 1. Go to '...'
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
       label: Expected behavior
-      description: What did you expect to happen?
-      placeholder: ex. I expected '...' to happen
+      description: What you expected to happen?
     validations:
       required: true
   - type: textarea
     id: actual-behavior
     attributes:
       label: Actual behavior
-      description: What did actually happen?
-      placeholder: ex. Instead '...' happened
+      description: What actually happened?
     validations:
       required: true
   - type: dropdown
     id: operating-system
     attributes:
       label: Operating system
-      description: Which operating system are you using?
+      description: What operating system are you using?
       options:
         - Windows
         - macOS
@@ -79,7 +75,7 @@ body:
     id: pycm-version
     attributes:
       label: PyCM version
-      description: Which version of PyCM are you using?
+      description: What version of PyCM are you using?
       options:
         - PyCM 4.0
         - PyCM 3.9

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,11 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for your time to fill out this bug report!
   - type: input
     id: contact
     attributes:
-      label: Contact Details
+      label: Contact details
       description: How can we get in touch with you if we need more info?
       placeholder: ex. email@example.com
     validations:
@@ -19,6 +19,8 @@ body:
     attributes:
       label: What happened?
       description: Provide a clear and concise description of what the bug is.
+      placeholder: >
+        Tell us a description of the bug.
     validations:
       required: true
   - type: textarea
@@ -26,27 +28,33 @@ body:
     attributes:
       label: Steps to reproduce
       description: Provide details of how to reproduce the bug.
+      placeholder: >
+        ex. 1. Go to '...'
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
       label: Expected behavior
-      description: What you expected to happen?
+      description: What did you expect to happen?
+      placeholder: >
+        ex. I expected '...' to happen
     validations:
       required: true
   - type: textarea
     id: actual-behavior
     attributes:
       label: Actual behavior
-      description: What actually happened?
+      description: What did actually happen?
+      placeholder: >
+        ex. Instead '...' happened
     validations:
       required: true
   - type: dropdown
     id: operating-system
     attributes:
       label: Operating system
-      description: What operating system are you using?
+      description: Which operating system are you using?
       options:
         - Windows
         - macOS
@@ -75,7 +83,7 @@ body:
     id: pycm-version
     attributes:
       label: PyCM version
-      description: What version of PyCM are you using?
+      description: Which version of PyCM are you using?
       options:
         - PyCM 4.0
         - PyCM 3.9

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,27 +6,23 @@ body:
     id: description
     attributes:
       label: Describe the feature you want to add
-      placeholder: I'd like to be able to [...]
     validations:
       required: true
   - type: textarea
     id: possible-solution
     attributes:
       label: Describe your proposed solution
-      placeholder: I think this could be done by [...]
     validations:
       required: false
   - type: textarea
     id: alternatives
     attributes:
       label: Describe alternatives you've considered, if relevant
-      placeholder: Another way to do this would be [...]
     validations:
       required: false
   - type: textarea
     id: aditional-context
     attributes:
       label: Additional context
-      placeholder: Add any other context or screenshots about the feature request here.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,23 +6,31 @@ body:
     id: description
     attributes:
       label: Describe the feature you want to add
+      placeholder: >
+        I'd like to be able to [...]
     validations:
       required: true
   - type: textarea
     id: possible-solution
     attributes:
       label: Describe your proposed solution
+      placeholder: >
+        I think this could be done by [...]
     validations:
       required: false
   - type: textarea
     id: alternatives
     attributes:
       label: Describe alternatives you've considered, if relevant
+      placeholder: >
+        Another way to do this would be [...]
     validations:
       required: false
   - type: textarea
     id: aditional-context
     attributes:
       label: Additional context
+      placeholder: >
+        Add any other context or screenshots about the feature request here.
     validations:
       required: false


### PR DESCRIPTION
#### Reference Issues/PRs
#526 
#### What does this implement/fix? Explain your changes.
There was an issue regarding the GitHub comments textarea. The placeholder value wouldn't replace the default placeholder. This PR solves that issue. You can check the online version of this change [here](https://github.com/sadrasabouri/test-github/issues/new/choose).