### PR TITLE
Type Hint (class_func, handlers, multi-labelcm, overall_funcs)

### DIFF
--- a/pycm/class_funcs.py
+++ b/pycm/class_funcs.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
 """Class statistics functions."""
 from __future__ import division
+from typing import Union, Dict, List, Any
 import math
 from .utils import normal_quantile
 from .interpret import *
 from .params import CLASS_PARAMS
 
 
-def sensitivity_index_calc(TPR, FPR):
+def sensitivity_index_calc(TPR: float, FPR: float) -> Union[float, str]:
     """
     Calculate Sensitivity index (d prime).
 
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
     :param FPR: fall-out or false positive rate
-    :type FPR: float
-    :return: sensitivity index as float
     """
     try:
         return normal_quantile(TPR) - normal_quantile(FPR)
@@ -23,19 +21,14 @@ def sensitivity_index_calc(TPR, FPR):
         return "None"
 
 
-def NB_calc(TP, FP, POP, w):
+def NB_calc(TP: int, FP: int, POP: int, w: float) -> Union[float, str]:
     """
     Calculate Net Benefit (NB).
 
     :param TP: true positive
-    :type TP: int
     :param FP: false positive
-    :type FP: int
     :param POP: population or total number of samples
-    :type POP: int
     :param w: weight
-    :type w: float
-    :return: NB as float
     """
     try:
         NB = (TP - w * FP) / POP
@@ -44,21 +37,15 @@ def NB_calc(TP, FP, POP, w):
         return "None"
 
 
-def TI_calc(TP, FP, FN, alpha, beta):
+def TI_calc(TP: int, FP: int, FN: int, alpha: float, beta: float) -> Union[float, str]:
     """
     Calculate Tversky index (TI).
 
     :param TP: true positive
-    :type TP: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
     :param alpha: alpha coefficient
-    :type alpha: float
     :param beta: beta coefficient
-    :type beta: float
-    :return: TI as float
     """
     try:
         TI = TP / (TP + alpha * FN + beta * FP)
@@ -67,17 +54,13 @@ def TI_calc(TP, FP, FN, alpha, beta):
         return "None"
 
 
-def OOC_calc(TP, TOP, P):
+def OOC_calc(TP: int, TOP: int, P: int) -> Union[float, str]:
     """
     Calculate Otsuka-Ochiai coefficient (OOC).
 
     :param TP: true positive
-    :type TP: int
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
-    :return: OOC as float
     """
     try:
         OOC = TP / (math.sqrt(TOP * P))
@@ -86,17 +69,13 @@ def OOC_calc(TP, TOP, P):
         return "None"
 
 
-def OC_calc(TP, TOP, P):
+def OC_calc(TP: int, TOP: int, P: int) -> Union[float, str]:
     """
     Calculate Overlap coefficient (OC).
 
     :param TP: true positive
-    :type TP: int
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
-    :return: overlap coefficient as float
     """
     try:
         overlap_coef = TP / min(TOP, P)
@@ -105,17 +84,13 @@ def OC_calc(TP, TOP, P):
         return "None"
 
 
-def BB_calc(TP, TOP, P):
+def BB_calc(TP: int, TOP: int, P: int) -> Union[float, str]:
     """
     Calculate Braun-Blanquet similarity (BB).
 
     :param TP: true positive
-    :type TP: int
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
-    :return: BB as float
     """
     try:
         BB = TP / max(TOP, P)
@@ -124,19 +99,14 @@ def BB_calc(TP, TOP, P):
         return "None"
 
 
-def AGF_calc(TP, FP, FN, TN):
+def AGF_calc(TP: int, FP: int, FN: int, TN: int) -> Union[float, str]:
     """
     Calculate Adjusted F-score (AGF).
 
     :param TP: true positive
-    :type TP: int
     :param TN: true negative
-    :type TN: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
-    :return: AGF as float
     """
     try:
         F2 = F_calc(TP=TP, FP=FP, FN=FN, beta=2)
@@ -147,21 +117,15 @@ def AGF_calc(TP, FP, FN, TN):
         return "None"
 
 
-def AGM_calc(TPR, TNR, GM, N, POP):
+def AGM_calc(TPR: float, TNR: float, GM: float, N: int, POP: int) -> Union[float, str]:
     """
     Calculate Adjusted geometric mean (AGM).
 
     :param TNR: specificity or true negative rate
-    :type TNR: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
     :param GM: geometric mean
-    :type GM: float
     :param N: number of actual negatives
-    :type N: int
     :param POP: population or total number of samples
-    :type POP: int
-    :return: AGM as float
     """
     try:
         n = N / POP
@@ -174,19 +138,14 @@ def AGM_calc(TPR, TNR, GM, N, POP):
         return "None"
 
 
-def Q_calc(TP, TN, FP, FN):
+def Q_calc(TP: int, TN: int, FP: int, FN: int) -> Union[float, str]:
     """
     Calculate Yule's Q.
 
     :param TP: true positive
-    :type TP: int
     :param TN: true negative
-    :type TN: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
-    :return: Yule's Q as float
     """
     try:
         OR = (TP * TN) / (FP * FN)
@@ -196,15 +155,12 @@ def Q_calc(TP, TN, FP, FN):
         return "None"
 
 
-def TTPN_calc(item1, item2):
+def TTPN_calc(item1: int, item2: int) -> Union[float, str]:
     """
-    Calculate TPR, TNR, PPV, and NPV.
+    Calculate TPR, TNR, PPV, or NPV.
 
     :param item1: item1 in fractional expression
-    :type item1: int
     :param item2: item2 in fractional expression
-    :type item2: int
-    :return: result as float
     """
     try:
         result = item1 / (item1 + item2)
@@ -213,13 +169,11 @@ def TTPN_calc(item1, item2):
         return "None"
 
 
-def FXR_calc(item):
+def FXR_calc(item: float) -> Union[float, str]:
     """
-    Calculate False negative rate, False positive rate, False discovery rate (FDR), and False omission rate (FOR).
+    Calculate False negative rate, False positive rate, False discovery rate (FDR), or False omission rate (FOR).
 
     :param item: item In expression
-    :type item:float
-    :return: result as float
     """
     try:
         result = 1 - item
@@ -228,19 +182,14 @@ def FXR_calc(item):
         return "None"
 
 
-def ACC_calc(TP, TN, FP, FN):
+def ACC_calc(TP: int, TN: int, FP: int, FN: int) -> Union[float, str]:
     """
     Calculate Accuracy.
 
     :param TP: true positive
-    :type TP: int
     :param TN: true negative
-    :type TN: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
-    :return: accuracy as float
     """
     try:
         result = (TP + TN) / (TP + TN + FN + FP)
@@ -249,19 +198,14 @@ def ACC_calc(TP, TN, FP, FN):
         return "None"
 
 
-def F_calc(TP, FP, FN, beta):
+def F_calc(TP: int, FP: int, FN: int, beta: float) -> Union[float, str]:
     """
     Calculate F-score.
 
     :param TP: true positive
-    :type TP: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
     :param beta: beta coefficient
-    :type beta: float
-    :return: F-score as float
     """
     try:
         result = ((1 + (beta)**2) * TP) / \
@@ -271,19 +215,14 @@ def F_calc(TP, FP, FN, beta):
         return "None"
 
 
-def MCC_calc(TP, TN, FP, FN):
+def MCC_calc(TP: int, TN: int, FP: int, FN: int) -> Union[float, str]:
     """
     Calculate Matthews correlation coefficient (MCC).
 
     :param TP: true positive
-    :type TP: int
     :param TN: true negative
-    :type TN: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
-    :return: MCC as float
     """
     try:
         result = (TP * TN - FP * FN) / \
@@ -293,15 +232,12 @@ def MCC_calc(TP, TN, FP, FN):
         return "None"
 
 
-def MK_BM_calc(item1, item2):
+def MK_BM_calc(item1: float, item2: float) -> Union[float, str]:
     """
-    Calculate Informedness (BM), Markedness (MK), and Individual classification success index (ICSI).
+    Calculate Informedness (BM), Markedness (MK), or Individual classification success index (ICSI).
 
     :param item1: item1 in expression
-    :type item1:float
     :param item2: item2 in expression
-    :type item2:float
-    :return: MK and BM as float
     """
     try:
         result = item1 + item2 - 1
@@ -310,15 +246,12 @@ def MK_BM_calc(item1, item2):
         return "None"
 
 
-def LR_calc(item1, item2):
+def LR_calc(item1: float, item2: float) -> Union[float, str]:
     """
     Calculate Likelihood ratio (LR).
 
     :param item1: item1 in expression
-    :type item1:float
     :param item2: item2 in expression
-    :type item2:float
-    :return: LR+ and LR- as float
     """
     try:
         result = item1 / item2
@@ -327,15 +260,12 @@ def LR_calc(item1, item2):
         return "None"
 
 
-def proportion_calc(item1, item2):
+def proportion_calc(item1: int, item2: int) -> Union[float, str]:
     """
     Calculate Prevalence.
 
     :param item1: item1 in fractional expression
-    :type item1: int
     :param item2: item2 in fractional expression
-    :type item2: int
-    :return: proportion as float
     """
     try:
         result = item1 / item2
@@ -344,15 +274,12 @@ def proportion_calc(item1, item2):
         return "None"
 
 
-def G_calc(item1, item2):
+def G_calc(item1: float, item2: float) -> Union[float, str]:
     """
-    Calculate G-measure & G-mean.
+    Calculate G-measure or G-mean.
 
     :param item1: True positive rate (TPR) or True negative rate (TNR) or Positive predictive value (PPV)
-    :type item1: float
     :param item2: True positive rate (TPR) or True negative rate (TNR) or Positive predictive value (PPV)
-    :type item2: float
-    :return: G-measure or G-mean as float
     """
     try:
         result = math.sqrt(item1 * item2)
@@ -361,17 +288,13 @@ def G_calc(item1, item2):
         return "None"
 
 
-def RACC_calc(TOP, P, POP):
+def RACC_calc(TOP: int, P: int, POP: int) -> Union[float, str]:
     """
     Calculate Random accuracy (RACC).
 
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
     :param POP: population or total number of samples
-    :type POP:int
-    :return: RACC as float
     """
     try:
         result = (TOP * P) / ((POP) ** 2)
@@ -380,17 +303,13 @@ def RACC_calc(TOP, P, POP):
         return "None"
 
 
-def RACCU_calc(TOP, P, POP):
+def RACCU_calc(TOP: int, P: int, POP: int) -> Union[float, str]:
     """
     Calculate Random accuracy unbiased (RACCU).
 
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
     :param POP: population or total number of samples
-    :type POP: int
-    :return: RACCU as float
     """
     try:
         result = ((TOP + P) / (2 * POP))**2
@@ -399,7 +318,7 @@ def RACCU_calc(TOP, P, POP):
         return "None"
 
 
-def ERR_calc(ACC):
+def ERR_calc(ACC: float) -> Union[float, str]:
     """
     Calculate Error rate.
 
@@ -413,17 +332,13 @@ def ERR_calc(ACC):
         return "None"
 
 
-def jaccard_index_calc(TP, TOP, P):
+def jaccard_index_calc(TP: int, TOP: int, P: int) -> Union[float, str]:
     """
     Calculate Jaccard index for each class.
 
     :param TP: true positive
-    :type TP: int
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
-    :return: Jaccard index as float
     """
     try:
         return TP / (TOP + P - TP)
@@ -431,19 +346,14 @@ def jaccard_index_calc(TP, TOP, P):
         return "None"
 
 
-def IS_calc(TP, FP, FN, POP):
+def IS_calc(TP: int, FP: int, FN: int, POP: int) -> Union[float, str]:
     """
     Calculate Information score (IS).
 
     :param TP: true positive
-    :type TP: int
     :param FP: false positive
-    :type FP: int
     :param FN: false negative
-    :type FN: int
     :param POP: population or total number of samples
-    :type POP: int
-    :return: IS as float
     """
     try:
         result = -math.log(((TP + FN) / POP), 2) + \
@@ -454,31 +364,23 @@ def IS_calc(TP, FP, FN, POP):
 
 
 def CEN_misclassification_calc(
-        table,
-        TOP,
-        P,
-        i,
-        j,
-        subject_class,
-        modified=False):
+        table: Dict[Any, Dict[Any, int]],
+        TOP: int,
+        P: int,
+        i: Any,
+        j: Any,
+        subject_class: Any,
+        modified: bool = False) -> Union[float, str]:
     """
     Calculate Misclassification probability.
 
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
     :param i: table row index (class name)
-    :type i: any valid type
     :param j: table col index (class name)
-    :type j: any valid type
     :param subject_class: subject to class (class name)
-    :type subject_class: any valid type
     :param modified: modified mode flag
-    :type modified: bool
-    :return: misclassification probability as float
     """
     try:
         result = TOP + P
@@ -490,23 +392,22 @@ def CEN_misclassification_calc(
         return "None"
 
 
-def CEN_calc(classes, table, TOP, P, class_name, modified=False):
+def CEN_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        TOP: int,
+        P: int,
+        class_name: Any,
+        modified: bool = False) -> Union[float, str]:
     """
     Calculate Confusion Entropy (CEN) (or Modified Confusion Entropy (MCEN)).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
     :param class_name: reviewed class name
-    :type class_name: any valid type
     :param modified: modified mode flag
-    :type modified: bool
-    :return: CEN (or MCEN) as float
     """
     try:
         result = 0
@@ -528,15 +429,12 @@ def CEN_calc(classes, table, TOP, P, class_name, modified=False):
         return "None"
 
 
-def AUC_calc(item, TPR):
+def AUC_calc(item: float, TPR: float) -> Union[float, str]:
     """
     Calculate Area under the ROC/PR curve for each class (AUC/AUPR).
 
     :param item: True negative rate (TNR) or Positive predictive value (PPV)
-    :type item: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
-    :return: AUC/AUPR as float
     """
     try:
         return (item + TPR) / 2
@@ -544,15 +442,12 @@ def AUC_calc(item, TPR):
         return "None"
 
 
-def dInd_calc(TNR, TPR):
+def dInd_calc(TNR: float, TPR: float) -> Union[float, str]:
     """
     Calculate Distance index (dInd).
 
     :param TNR: specificity or true negative rate
-    :type TNR: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
-    :return: dInd as float
     """
     try:
         result = math.sqrt(((1 - TNR)**2) + ((1 - TPR)**2))
@@ -561,13 +456,11 @@ def dInd_calc(TNR, TPR):
         return "None"
 
 
-def sInd_calc(dInd):
+def sInd_calc(dInd: float) -> Union[float, str]:
     """
     Calculate Similarity index (sInd).
 
     :param dInd: dInd
-    :type dInd: float
-    :return: sInd as float
     """
     try:
         return 1 - (dInd / (math.sqrt(2)))
@@ -575,15 +468,12 @@ def sInd_calc(dInd):
         return "None"
 
 
-def DP_calc(TPR, TNR):
+def DP_calc(TPR: float, TNR: float) -> Union[float, str]:
     """
     Calculate Discriminant power (DP).
 
     :param TNR: specificity or true negative rate
-    :type TNR: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
-    :return: DP as float
     """
     try:
         X = TPR / (1 - TPR)
@@ -593,13 +483,11 @@ def DP_calc(TPR, TNR):
         return "None"
 
 
-def GI_calc(AUC):
+def GI_calc(AUC: float) -> Union[float, str]:
     """
     Calculate Gini index.
 
-    :param AUC: Area under the ROC
-    :type AUC: float
-    :return: Gini index as float
+    :param AUC: Area under the ROC curve
     """
     try:
         return 2 * AUC - 1
@@ -607,15 +495,12 @@ def GI_calc(AUC):
         return "None"
 
 
-def lift_calc(PPV, PRE):
+def lift_calc(PPV: float, PRE: float) -> Union[float, str]:
     """
     Calculate Lift score.
 
     :param PPV: Positive predictive value (PPV)
-    :type PPV: float
     :param PRE: Prevalence
-    :type PRE: float
-    :return: lift score as float
     """
     try:
         return PPV / PRE
@@ -623,15 +508,12 @@ def lift_calc(PPV, PRE):
         return "None"
 
 
-def AM_calc(TOP, P):
+def AM_calc(TOP: int, P: int) -> Union[int, str]:
     """
     Calculate Automatic/Manual (AM).
 
     :param TOP: number of positives in predict vector
-    :type TOP: int
     :param P: number of actual positives
-    :type P: int
-    :return: AM as int
     """
     try:
         return TOP - P
@@ -639,17 +521,13 @@ def AM_calc(TOP, P):
         return "None"
 
 
-def OP_calc(ACC, TPR, TNR):
+def OP_calc(ACC: float, TPR: float, TNR: float) -> Union[float, str]:
     """
     Calculate Optimized precision (OP).
 
     :param ACC: accuracy
-    :type ACC: float
     :param TNR: specificity or true negative rate
-    :type TNR: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
-    :return: OP as float
     """
     try:
         RI = abs(TNR - TPR) / (TPR + TNR)
@@ -658,17 +536,13 @@ def OP_calc(ACC, TPR, TNR):
         return "None"
 
 
-def IBA_calc(TPR, TNR, alpha=1):
+def IBA_calc(TPR: float, TNR: float, alpha: float = 1) -> Union[float, str]:
     """
     Calculate Index of balanced accuracy (IBA).
 
     :param TNR: specificity or true negative rate
-    :type TNR: float
     :param TPR: sensitivity, recall, hit rate, or true positive rate
-    :type TPR: float
     :param alpha: alpha coefficient
-    :type alpha: float
-    :return: IBA as float
     """
     try:
         IBA = (1 + alpha * (TPR - TNR)) * TPR * TNR
@@ -677,15 +551,12 @@ def IBA_calc(TPR, TNR, alpha=1):
         return "None"
 
 
-def BCD_calc(AM, POP):
+def BCD_calc(AM: int, POP: int) -> Union[float, str]:
     """
     Calculate Bray-Curtis dissimilarity (BCD).
 
     :param AM: Automatic/Manual
-    :type AM: int
     :param POP: population or total number of samples
-    :type POP: int
-    :return: BCD as float
     """
     try:
         return abs(AM) / (2 * POP)
@@ -693,19 +564,18 @@ def BCD_calc(AM, POP):
         return "None"
 
 
-def basic_statistics(TP, TN, FP, FN):
+def basic_statistics(
+        TP: Dict[Any, int],
+        TN: Dict[Any, int],
+        FP: Dict[Any, int],
+        FN: Dict[Any, int]) -> Dict[str, Dict[Any, int]]:
     """
     Init classes' statistics.
 
     :param TP: true positive
-    :type TP: dict
     :param TN: true negative
-    :type TN: dict
     :param FP: false positive
-    :type FP: dict
     :param FN: false negative
-    :type FN: dict
-    :return: basic statistics as dict
     """
     result = {}
     for i in CLASS_PARAMS:
@@ -717,23 +587,22 @@ def basic_statistics(TP, TN, FP, FN):
     return result
 
 
-def class_statistics(TP, TN, FP, FN, classes, table):
+def class_statistics(
+        TP: Dict[Any, int],
+        TN: Dict[Any, int],
+        FP: Dict[Any, int],
+        FN: Dict[Any, int],
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]]) -> Dict[str, Dict[Any, Union[float, int, str]]]:
     """
     Return All statistics of classes.
 
     :param TP: true positive
-    :type TP: dict
     :param TN: true negative
-    :type TN: dict
     :param FP: false positive
-    :type FP: dict
     :param FN: false negative
-    :type FN: dict
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
-    :return: classes' statistics as dict
     """
     result = basic_statistics(TP, TN, FP, FN)
     for i in TP:

--- a/pycm/compare.py
+++ b/pycm/compare.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Compare module."""
-from __future__ import division
+from __future__ import division, annotations
 from typing import Dict, Optional, Union
 from .errors import pycmCompareError
 from .output import *
@@ -36,7 +36,7 @@ class Compare():
 
     def __init__(
             self,
-            cm_dict: Dict[str, "pycm.ConfusionMatrix"],
+            cm_dict: Dict[str, ConfusionMatrix],
             by_class: bool=False,
             class_weight: Optional[dict]=None,
             class_benchmark_weight: Optional[dict]=None,
@@ -121,7 +121,7 @@ class Compare():
         return report
 
 
-def __compare_class_handler__(compare: "pycm.Compare", cm_dict: Dict[str, "pycm.ConfusionMatrix"]) -> None:
+def __compare_class_handler__(compare: Compare, cm_dict: Dict[str, ConfusionMatrix]) -> None:
     """
     Handle class score of Compare class.
 
@@ -144,7 +144,7 @@ def __compare_class_handler__(compare: "pycm.Compare", cm_dict: Dict[str, "pycm.
                     compare.scores[cm_name]["class"] += score
 
 
-def __compare_overall_handler__(compare: "pycm.Compare", cm_dict: Dict[str, "pycm.ConfusionMatrix"]) -> None:
+def __compare_overall_handler__(compare: Compare, cm_dict: Dict[str, ConfusionMatrix]) -> None:
     """
     Handle overall score of Compare class.
 
@@ -166,11 +166,11 @@ def __compare_overall_handler__(compare: "pycm.Compare", cm_dict: Dict[str, "pyc
                 compare.scores[cm_name]["overall"] += score
 
 
-def __compare_rounder__(compare: "pycm.Compare", cm_dict: Dict[str, "pycm.ConfusionMatrix"]) -> None:
+def __compare_rounder__(compare: Compare, cm_dict: Dict[str, ConfusionMatrix]) -> None:
     """
     Round Compare.scores .
 
-    :param compare: Compare
+    :param compare: Compare object
     :param cm_dict: dictionary of confusion matrices
     """
     for cm_name in cm_dict:
@@ -180,7 +180,7 @@ def __compare_rounder__(compare: "pycm.Compare", cm_dict: Dict[str, "pycm.Confus
             compare.scores[cm_name]["class"], compare.digit)
 
 
-def __compare_sort_handler__(compare: "pycm.Compare") -> Tuple[str, str]:
+def __compare_sort_handler__(compare: Compare) -> Tuple[str, str]:
     """
     Handle sorting of scores.
 
@@ -204,7 +204,7 @@ def __compare_sort_handler__(compare: "pycm.Compare") -> Tuple[str, str]:
     return (max_overall_name, max_class_name)
 
 
-def __compare_weight_handler__(compare: "pycm.Compare", weight: Dict[str, float], weight_type: str) -> None:
+def __compare_weight_handler__(compare: Compare, weight: Dict[str, float], weight_type: str) -> None:
     """
     Handle different weights validation.
 
@@ -239,8 +239,8 @@ def __compare_weight_handler__(compare: "pycm.Compare", weight: Dict[str, float]
 
 
 def __compare_assign_handler__(
-        compare: "pycm.Compare",
-        cm_dict: Dict[str, "pycm.ConfusionMatrix"],
+        compare: Compare,
+        cm_dict: Dict[str, ConfusionMatrix],
         class_weight: Dict[str, float],
         class_benchmark_weight: Dict[str, float],
         overall_benchmark_weight: Dict[str, float],

--- a/pycm/curve.py
+++ b/pycm/curve.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Curve module."""
-from __future__ import division
+from __future__ import division, annotations
 from typing import List, Tuple, Dict, Optional, Union, Any
 from .errors import pycmCurveError, pycmPlotError
 from .utils import threshold_func, thresholds_calc, isfloat
@@ -217,7 +217,7 @@ class PRCurve(Curve):
         return "pycm.PRCurve(classes: " + str(self.classes) + ")"
 
 
-def __curve_validation__(curve: "pycm.Curve",
+def __curve_validation__(curve: Curve,
                          actual_vector: Union[List[Any],
                                               numpy.ndarray],
                          probs: Union[List[float],
@@ -243,7 +243,7 @@ def __curve_validation__(curve: "pycm.Curve",
     curve.probs = probs
 
 
-def __plot_validation__(curve: "pycm.Curve",
+def __plot_validation__(curve: Curve,
                         classes: List[Any],
                         area: bool,
                         area_method: str,
@@ -277,7 +277,7 @@ def __plot_validation__(curve: "pycm.Curve",
     return fig, ax, classes
 
 
-def __curve_classes_handler__(curve: "pycm.Curve", classes: List[Any]) -> None:
+def __curve_classes_handler__(curve: Curve, classes: List[Any]) -> None:
     """
     Handle conditions for curve classes.
 
@@ -301,7 +301,7 @@ def __curve_classes_handler__(curve: "pycm.Curve", classes: List[Any]) -> None:
         curve.classes = list(map(str, curve.classes))
 
 
-def __curve_thresholds_handler__(curve: "pycm.Curve", thresholds: Union[List[float], numpy.ndarray]) -> None:
+def __curve_thresholds_handler__(curve: Curve, thresholds: Union[List[float], numpy.ndarray]) -> None:
     """
     Handle conditions for thresholds.
 
@@ -323,7 +323,7 @@ def __curve_thresholds_handler__(curve: "pycm.Curve", thresholds: Union[List[flo
         curve.thresholds = sorted(curve.thresholds)
 
 
-def __curve_data_filter__(curve: "pycm.Curve") -> None:
+def __curve_data_filter__(curve: Curve) -> None:
     """
     Eliminate and refine the points at which the curve is undefined.
 

--- a/pycm/handlers.py
+++ b/pycm/handlers.py
@@ -45,7 +45,14 @@ def __imbalancement_handler__(cm: "pycm.ConfusionMatrix", is_imbalanced: bool) -
         cm.imbalance = is_imbalanced
 
 
-def __obj_assign_handler__(cm: "pycm.ConfusionMatrix", matrix_param: Dict[int, Any]) -> None:
+def __obj_assign_handler__(
+        cm: "pycm.ConfusionMatrix",
+        matrix_param: Tuple[List[Any],
+                            Dict[Any, Dict[Any, int]],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int]]) -> None:
     """
     Assign basic parameters to the input confusion matrix.
 

--- a/pycm/handlers.py
+++ b/pycm/handlers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """ConfusionMatrix handlers."""
 from __future__ import division
+from typing import Dict, IO
 from .class_funcs import class_statistics
 from .errors import pycmVectorError, pycmMatrixError
 from .overall_funcs import overall_statistics
@@ -11,39 +12,32 @@ import types
 import numpy
 
 
-def __class_stat_init__(cm):
+def __class_stat_init__(cm: "pycm.ConfusionMatrix") -> None:
     """
     Init individual class stats.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
-    :return: None
     """
     for stat, field_name in CLASS_PARAMS.items():
         setattr(cm, field_name, cm.class_stat[stat])
 
 
-def __overall_stat_init__(cm):
+def __overall_stat_init__(cm: "pycm.ConfusionMatrix") -> None:
     """
     Init individual overall stats.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
-    :return: None
     """
     for stat, field_name in OVERALL_PARAMS.items():
         setattr(cm, field_name, cm.overall_stat[stat])
 
 
-def __imbalancement_handler__(cm, is_imbalanced):
+def __imbalancement_handler__(cm: "pycm.ConfusionMatrix", is_imbalanced: bool) -> None:
     """
     Check if the confusion matrix is imbalanced.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
     :param is_imbalanced: is imbalanced flag passed to __init__
-    :type is_imbalanced: bool
-    :return: None
     """
     if cm.imbalance is None:
         if is_imbalanced is None:
@@ -51,15 +45,12 @@ def __imbalancement_handler__(cm, is_imbalanced):
         cm.imbalance = is_imbalanced
 
 
-def __obj_assign_handler__(cm, matrix_param):
+def __obj_assign_handler__(cm: "pycm.ConfusionMatrix", matrix_param: Dict[int, Any]) -> None:
     """
     Assign basic parameters to the input confusion matrix.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
     :param matrix_param: matrix parameters
-    :type matrix_param: dict
-    :return: None
     """
     cm.classes = matrix_param[0]
     cm.table = matrix_param[1]
@@ -109,15 +100,17 @@ def __obj_assign_handler__(cm, matrix_param):
             zip(OVERALL_PARAMS.keys(), len(OVERALL_PARAMS) * ["None"]))
 
 
-def __obj_file_handler__(cm, file):
+def __obj_file_handler__(cm: "pycm.ConfusionMatrix", file: IO) -> Tuple[List[Any],
+                                                                        Dict[Any, Dict[Any, int]],
+                                                                        Dict[Any, int],
+                                                                        Dict[Any, int],
+                                                                        Dict[Any, int],
+                                                                        Dict[Any, int]]:
     """
     Handle object conditions for the input file.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
     :param file: saved confusion matrix file object
-    :type file: (io.IOBase & file)
-    :return: matrix parameters as list
     """
     obj_data = json.load(file)
     if obj_data["Actual-Vector"] is not None and obj_data[
@@ -147,17 +140,21 @@ def __obj_file_handler__(cm, file):
     return matrix_param
 
 
-def __obj_matrix_handler__(matrix, classes, transpose):
+def __obj_matrix_handler__(
+        matrix: Dict[Any, Dict[Any, int]],
+        classes: List[Any],
+        transpose: bool) -> Tuple[List[Any],
+                            Dict[Any, Dict[Any, int]],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int]]:
     """
     Handle object conditions for the matrix.
 
     :param matrix: the confusion matrix in dict form
-    :type matrix: dict
     :param classes: ordered labels of classes
-    :type classes: list
     :param transpose: transpose flag
-    :type transpose: bool
-    :return: matrix parameters as list
     """
     if matrix_check(matrix):
         if class_check(list(matrix)) is False:
@@ -169,17 +166,21 @@ def __obj_matrix_handler__(matrix, classes, transpose):
     return matrix_param
 
 
-def __obj_array_handler__(array, classes, transpose):
+def __obj_array_handler__(
+        array: Union[List[List[int]], numpy.ndarray],
+        classes: List[Any],
+        transpose: bool) -> Tuple[List[Any],
+                            Dict[Any, Dict[Any, int]],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int],
+                            Dict[Any, int]]:
     """
     Handle object conditions for the array.
 
     :param matrix: the confusion matrix in array form
-    :type matrix: list or np.array
     :param classes: ordered labels of classes
-    :type classes: list
     :param transpose: transpose flag
-    :type transpose: bool
-    :return: matrix parameters as list
     """
     if classes is not None and len(set(classes)) != len(classes):
         raise pycmMatrixError(VECTOR_UNIQUE_CLASS_ERROR)
@@ -194,28 +195,26 @@ def __obj_array_handler__(array, classes, transpose):
 
 
 def __obj_vector_handler__(
-        cm,
-        actual_vector,
-        predict_vector,
-        threshold,
-        sample_weight,
-        classes):
+        cm: "pycm.ConfusionMatrix",
+        actual_vector: Union[List[Any], numpy.ndarray],
+        predict_vector: Union[List[Any], numpy.ndarray],
+        threshold: Callable,
+        sample_weight: Union[List[Any], numpy.ndarray],
+        classes: List[Any]) -> Tuple[List[Any],
+                               Dict[Any, Dict[Any, int]],
+                               Dict[Any, int],
+                               Dict[Any, int],
+                               Dict[Any, int],
+                               Dict[Any, int]]:
     """
     Handle object conditions for vectors.
 
     :param cm: confusion matrix
-    :type cm: pycm.ConfusionMatrix object
     :param actual_vector: actual vector
-    :type actual_vector: python list or numpy array of any stringable objects
     :param predict_vector: vector of predictions
-    :type predict_vector: python list or numpy array of any stringable objects
     :param threshold: activation threshold function
-    :type threshold: FunctionType (function or lambda)
     :param sample_weight: sample weights list
-    :type sample_weight: list
     :param classes: ordered labels of classes
-    :type classes: list
-    :return: matrix parameters as list
     """
     if isinstance(threshold, types.FunctionType):
         cm.prob_vector = predict_vector

--- a/pycm/multilabel_cm.py
+++ b/pycm/multilabel_cm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """MultiLabelCM module."""
 from __future__ import division, annotations
-from typing import List, Set, Any, Union
+from typing import List, Set, Any, Union, Optional
 from .errors import pycmVectorError, pycmMultiLabelError
 from .params import *
 from .cm import ConfusionMatrix
@@ -23,8 +23,8 @@ class MultiLabelCM():
             self,
             actual_vector: Union[List[Set[Any]], numpy.ndarray],
             predict_vector: Union[List[Set[Any]], numpy.ndarray],
-            sample_weight: Union[List[float], numpy.ndarray] = None,
-            classes: List[Any] = None) -> None:
+            sample_weight: Optional[Union[List[float], numpy.ndarray]] = None,
+            classes: Optional[List[Any]] = None) -> None:
         """
         Init method.
 

--- a/pycm/multilabel_cm.py
+++ b/pycm/multilabel_cm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """MultiLabelCM module."""
-from __future__ import division
+from __future__ import division, annotations
+from typing import List, Set, Any, Union
 from .errors import pycmVectorError, pycmMultiLabelError
 from .params import *
 from .cm import ConfusionMatrix
@@ -20,21 +21,17 @@ class MultiLabelCM():
 
     def __init__(
             self,
-            actual_vector,
-            predict_vector,
-            sample_weight=None,
-            classes=None):
+            actual_vector: Union[List[Set[Any]], numpy.ndarray],
+            predict_vector: Union[List[Set[Any]], numpy.ndarray],
+            sample_weight: Union[List[float], numpy.ndarray] = None,
+            classes: List[Any] = None) -> None:
         """
         Init method.
 
         :param actual_vector: actual vector
-        :type actual_vector: python list or numpy array of sets
         :param predict_vector: vector of predictions
-        :type predict_vector: python list or numpy array of sets
         :param sample_weight: sample weights list
-        :type sample_weight: python list or numpy array
         :param classes: ordered labels of classes
-        :type classes: list
         """
         self.actual_vector = actual_vector
         self.actual_vector_multihot = []
@@ -53,13 +50,11 @@ class MultiLabelCM():
         __mlcm_assign_classes__(self, classes)
         __mlcm_vectors_filter__(self)
 
-    def get_cm_by_class(self, class_name):
+    def get_cm_by_class(self, class_name: Any) -> ConfusionMatrix:
         """
         Return confusion matrices based on classes.
 
         :param class_name: target class name for confusion matrix
-        :type class_name: any valid type
-        :return: confusion matrix corresponding to the given class name
         """
         if class_name not in self.classwise_cms:
             try:
@@ -80,13 +75,11 @@ class MultiLabelCM():
             return cm
         return self.classwise_cms[class_name]
 
-    def get_cm_by_sample(self, index):
+    def get_cm_by_sample(self, index: int) -> ConfusionMatrix:
         """
         Return confusion matrices based on samples.
 
         :param index: sample index for confusion matrix
-        :type index: int
-        :return: confusion matrix corresponding to the given sample number
         """
         if index < 0 or index >= len(self.actual_vector):
             raise pycmMultiLabelError(VECTOR_INDEX_ERROR)
@@ -99,51 +92,33 @@ class MultiLabelCM():
             return cm
         return self.samplewise_cms[index]
 
-    def __str__(self):
-        """
-        Multilabel confusion matrix object string representation method.
-
-        :return: representation as str
-        """
+    def __str__(self) -> str:
+        """Multilabel confusion matrix object string representation method."""
         return self.__repr__()
 
-    def __repr__(self):
-        """
-        Multilabel confusion matrix object representation method.
-
-        :return: representation as str
-        """
+    def __repr__(self) -> str:
+        """Multilabel confusion matrix object representation method."""
         return "pycm.MultiLabelCM(classes: " + str(self.classes) + ")"
 
-    def __len__(self):
-        """
-        Multilabel confusion matrix object length method.
-
-        :return: length as int
-        """
+    def __len__(self) -> int:
+        """Multilabel confusion matrix object length method."""
         return len(self.classes)
 
 
 def __mlcm_vector_handler__(
-        mlcm,
-        actual_vector,
-        predict_vector,
-        sample_weight,
-        classes):
+        mlcm: MultiLabelCM,
+        actual_vector: Union[List[Set[Any]], numpy.ndarray],
+        predict_vector: Union[List[Set[Any]], numpy.ndarray],
+        sample_weight: Union[List[float], numpy.ndarray],
+        classes: List[Any]) -> None:
     """
     Handle multilabel object conditions for vectors.
 
     :param mlcm: multilabel confusion matrix
-    :type mlcm: pycm.MultiLabelCM object
     :param actual_vector: actual vector
-    :type actual_vector: python list or numpy array of sets
     :param predict_vector: vector of predictions
-    :type predict_vector: python list or numpy array of sets
     :param sample_weight: sample weights list
-    :type sample_weight: python list or numpy array
     :param classes: ordered labels of classes
-    :type classes: list
-    :return: None
     """
     if not isinstance(actual_vector, (list, numpy.ndarray)) or not \
             isinstance(predict_vector, (list, numpy.ndarray)):
@@ -163,16 +138,13 @@ def __mlcm_vector_handler__(
 
 
 def __mlcm_assign_classes__(
-        mlcm,
-        classes):
+        mlcm: MultiLabelCM,
+        classes: List[Any]) -> None:
     """
     Assign multilabel object class.
 
     :param mlcm: multilabel confusion matrix
-    :type mlcm: pycm.MultiLabelCM object
     :param classes: ordered labels of classes
-    :type classes: list
-    :return: None
     """
     mlcm.classes = classes
     if classes is None:
@@ -183,15 +155,11 @@ def __mlcm_assign_classes__(
                     *mlcm.predict_vector)))
 
 
-def __mlcm_vectors_filter__(mlcm):
+def __mlcm_vectors_filter__(mlcm: MultiLabelCM) -> None:
     """
     Normalize multilabel object vectors.
 
     :param mlcm: multilabel confusion matrix
-    :type mlcm: pycm.MultiLabelCM object
-    :param classes: ordered labels of classes
-    :type classes: list
-    :return: None
     """
     mlcm.actual_vector_multihot = [__set_to_multihot__(
         x, mlcm.classes) for x in mlcm.actual_vector]
@@ -199,15 +167,12 @@ def __mlcm_vectors_filter__(mlcm):
         x, mlcm.classes) for x in mlcm.predict_vector]
 
 
-def __set_to_multihot__(input_set, classes):
+def __set_to_multihot__(input_set: Set[Any], classes: List[Any]) -> List[int]:
     """
     Convert a set into a multi-hot vector based in classes.
 
     :param input_set: input set
-    :type input_set: set
     :param classes: ordered labels of classes
-    :type classes: list
-    :return: multi-hot vector as a list
     """
     result = [0] * len(classes)
     for i, x in enumerate(classes):

--- a/pycm/overall_funcs.py
+++ b/pycm/overall_funcs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Overall statistics functions."""
 from __future__ import division
+from typing import List, Dict, Tuple, Union, Any
 import math
 import operator as op
 from functools import reduce
@@ -10,28 +11,21 @@ from .utils import complement
 
 
 def log_loss_calc(
-        classes,
-        prob_vector,
-        actual_vector,
-        normalize=True,
-        sample_weight=None,
-        pos_class=None):
+        classes: List[Any],
+        prob_vector: List[float],
+        actual_vector: List[int],
+        normalize: bool = True,
+        sample_weight: List[float] = None,
+        pos_class: Union[int, str] = None) -> Union[float, str]:
     """
     Calculate Log loss.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param prob_vector: probability vector
-    :type prob_vector: python list or numpy array
     :param actual_vector: actual vector
-    :type actual_vector: python list or numpy array
     :param normalize: normalization flag
-    :type normalize: bool
     :param sample_weight: sample weights list
-    :type sample_weight: list
     :param pos_class: positive class name
-    :type pos_class: int/str
-    :return: Log loss as float
     """
     try:
         vector_length = len(actual_vector)
@@ -55,25 +49,19 @@ def log_loss_calc(
 
 
 def brier_score_calc(
-        classes,
-        prob_vector,
-        actual_vector,
-        sample_weight=None,
-        pos_class=None):
+        classes: List[Any],
+        prob_vector: List[float],
+        actual_vector: List[int],
+        sample_weight: List[float] = None,
+        pos_class: Union[int, str] = None) -> Union[float, str]:
     """
     Calculate Brier score.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param prob_vector: probability vector
-    :type prob_vector: python list or numpy array
     :param actual_vector: actual vector
-    :type actual_vector: python list or numpy array
     :param sample_weight: sample weights list
-    :type sample_weight: list
     :param pos_class: positive class name
-    :type pos_class: int/str
-    :return: Brier score as float
     """
     try:
         vector_length = len(actual_vector)
@@ -94,25 +82,24 @@ def brier_score_calc(
         return "None"
 
 
-def alpha2_calc(TOP, P, ACC, POP, classes, max_iter=200, epsilon=0.0001):
+def alpha2_calc(
+        TOP: Dict[Any, int],
+        P: Dict[Any, int],
+        ACC: float,
+        POP: Dict[Any, int],
+        classes: List[Any],
+        max_iter: int = 200,
+        epsilon: float = 0.0001) -> Union[float, str]:
     """
     Calculate Aickin's alpha.
 
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param ACC: accuracy
-    :type ACC: float
     :param POP: population or total number of samples per class
-    :type POP: dict
     :param classes: confusion matrix classes
-    :type classes: list
     :param max_iter: maximum iteration
-    :type max_iter: int
     :param epsilon: difference threshold
-    :type epsilon: float
-    :return: Aickin's alpha as float
     """
     try:
         p_A = {i: TOP[i] / POP[i] for i in classes}
@@ -138,17 +125,13 @@ def alpha2_calc(TOP, P, ACC, POP, classes, max_iter=200, epsilon=0.0001):
         return "None"
 
 
-def alpha_calc(RACC, ACC, POP):
+def alpha_calc(RACC: float, ACC: float, POP: int) -> Union[float, str]:
     """
     Calculate Unweighted Krippendorff's alpha.
 
     :param RACC: random accuracy
-    :type RACC: float
     :param ACC: accuracy
-    :type ACC: float
     :param POP: population or total number of samples
-    :type POP: int
-    :return: unweighted alpha as float
     """
     try:
         epsi = 1 / (2 * POP)
@@ -159,23 +142,22 @@ def alpha_calc(RACC, ACC, POP):
         return "None"
 
 
-def weighted_alpha_calc(classes, table, P, TOP, POP, weight):
+def weighted_alpha_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        P: Dict[Any, int],
+        TOP: Dict[Any, int],
+        POP: Dict[Any, int],
+        weight: Dict[Any, Dict[Any, float]]) -> Union[float, str]:
     """
     Calculate Weighted Krippendorff's alpha.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
     :param weight: weight matrix
-    :type weight: dict
-    :return: weighted alpha as float
     """
     p_e = 0
     p_a = 0
@@ -195,19 +177,18 @@ def weighted_alpha_calc(classes, table, P, TOP, POP, weight):
         return "None"
 
 
-def B_calc(classes, TP, TOP, P):
+def B_calc(
+        classes: List[Any],
+        TP: Dict[Any, int],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Bangdiwala's B (B).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param TP: true positive
-    :type TP: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
-    :return: B as float
     """
     try:
         up = 0
@@ -221,21 +202,20 @@ def B_calc(classes, TP, TOP, P):
         return "None"
 
 
-def ARI_calc(classes, table, TOP, P, POP):
+def ARI_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int],
+        POP: int) -> Union[float, str]:
     """
     Calculate Adjusted Rand index (ARI).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: ARI as float
     """
     try:
         table_sum = 0
@@ -254,15 +234,12 @@ def ARI_calc(classes, table, TOP, P, POP):
         return "None"
 
 
-def pearson_C_calc(chi_square, POP):
+def pearson_C_calc(chi_square: float, POP: int) -> Union[float, str]:
     """
     Calculate Pearson's C (C).
 
     :param chi_square: chi squared
-    :type chi_square: float
     :param POP: population or total number of samples
-    :type POP: int
-    :return: C as float
     """
     try:
         C = math.sqrt(chi_square / (POP + chi_square))
@@ -271,15 +248,12 @@ def pearson_C_calc(chi_square, POP):
         return "None"
 
 
-def RCI_calc(mutual_information, reference_entropy):
+def RCI_calc(mutual_information: float, reference_entropy: float) -> Union[float, str]:
     """
     Calculate Relative classifier information (RCI).
 
     :param mutual_information: mutual information
-    :type mutual_information: float
     :param reference_entropy: reference entropy
-    :type reference_entropy: float
-    :return: RCI as float
     """
     try:
         return mutual_information / reference_entropy
@@ -287,19 +261,18 @@ def RCI_calc(mutual_information, reference_entropy):
         return "None"
 
 
-def AUNP_calc(classes, P, POP, AUC_dict):
+def AUNP_calc(
+        classes: List[Any],
+        P: Dict[Any, int],
+        POP: Dict[Any, int],
+        AUC_dict: Dict[Any, float]) -> Union[float, str]:
     """
     Calculate AUNP.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
     :param AUC_dict: Area under the ROC curve (AUC) for each class
-    :type AUC_dict: dict
-    :return: AUNP as float
     """
     try:
         result = 0
@@ -310,19 +283,18 @@ def AUNP_calc(classes, P, POP, AUC_dict):
         return "None"
 
 
-def CBA_calc(classes, table, TOP, P):
+def CBA_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Class balance accuracy (CBA).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
-    :return: CBA as float
     """
     try:
         result = 0
@@ -334,15 +306,12 @@ def CBA_calc(classes, table, TOP, P):
         return "None"
 
 
-def RR_calc(classes, TOP):
+def RR_calc(classes: List[Any], TOP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Global performance index (RR).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
-    :return: RR as float
     """
     try:
         class_number = len(classes)
@@ -352,19 +321,18 @@ def RR_calc(classes, TOP):
         return "None"
 
 
-def overall_MCC_calc(classes, table, TOP, P):
+def overall_MCC_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Overall_MCC.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
-    :return: Overall_MCC as float
     """
     try:
         cov_x_y = 0
@@ -380,23 +348,22 @@ def overall_MCC_calc(classes, table, TOP, P):
         return "None"
 
 
-def convex_combination(classes, TP, TOP, P, class_name, modified=False):
+def convex_combination(
+        classes: List[Any],
+        TP: Dict[Any, int],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int],
+        class_name: Any,
+        modified: bool = False) -> Union[float, str]:
     """
     Calculate Overall_CEN coefficient.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param TP: true positive
-    :type TP: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param class_name: reviewed class name
-    :type class_name: any valid type
     :param modified: modified mode flag
-    :type modified: bool
-    :return: Overall_CEN coefficient as float
     """
     try:
         class_number = len(classes)
@@ -415,23 +382,22 @@ def convex_combination(classes, TP, TOP, P, class_name, modified=False):
         return "None"
 
 
-def overall_CEN_calc(classes, TP, TOP, P, CEN_dict, modified=False):
+def overall_CEN_calc(
+        classes: List[Any],
+        TP: Dict[Any, int],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int],
+        CEN_dict: Dict[Any, float],
+        modified: bool = False) -> Union[float, str]:
     """
     Calculate Overall_CEN (Overall confusion entropy).
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param TP: true positive
-    :type TP: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param CEN_dict: CEN dictionary for each class
-    :type CEN_dict: dict
     :param modified: modified mode flag
-    :type modified: bool
-    :return: Overall_CEN(MCEN) as float
     """
     try:
         result = 0
@@ -443,15 +409,12 @@ def overall_CEN_calc(classes, TP, TOP, P, CEN_dict, modified=False):
         return "None"
 
 
-def ncr(n, r):
+def ncr(n: int, r: int) -> int:
     """
     Calculate the combination of n and r.
 
     :param n: n
-    :type n: int
     :param r: r
-    :type r :int
-    :return: the combination of n and r as int
     """
     if r > n:
         return 0
@@ -461,17 +424,16 @@ def ncr(n, r):
     return numer // denom
 
 
-def p_value_calc(TP, POP, NIR):
+def p_value_calc(
+        TP: Dict[Any, int],
+        POP: int,
+        NIR: float) -> Union[float, str]:
     """
     Calculate p_value.
 
     :param TP: true positive
-    :type TP: dict
     :param POP: population or total number of samples
-    :type POP: int
     :param NIR: no information rate
-    :type NIR: float
-    :return: p_value as float
     """
     try:
         n = POP
@@ -485,15 +447,12 @@ def p_value_calc(TP, POP, NIR):
         return "None"
 
 
-def NIR_calc(P, POP):
+def NIR_calc(P: Dict[Any, int], POP: int) -> Union[float, str]:
     """
     Calculate No information rate (NIR).
 
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: NIR as float
     """
     try:
         max_P = max(list(P.values()))
@@ -503,15 +462,12 @@ def NIR_calc(P, POP):
         return "None"
 
 
-def hamming_calc(TP, POP):
+def hamming_calc(TP: Dict[Any, int], POP: int) -> Union[float, str]:
     """
     Calculate Hamming loss.
 
     :param TP: true positive
-    :type TP: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: Hamming loss as float
     """
     try:
         length = POP
@@ -520,15 +476,12 @@ def hamming_calc(TP, POP):
         return "None"
 
 
-def zero_one_loss_calc(TP, POP):
+def zero_one_loss_calc(TP: Dict[Any, int], POP: int) -> Union[int, str]:
     """
     Calculate Zero-one loss.
 
     :param TP: true Positive
-    :type TP: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: Zero-one loss as integer
     """
     try:
         length = POP
@@ -537,15 +490,12 @@ def zero_one_loss_calc(TP, POP):
         return "None"
 
 
-def entropy_calc(item, POP):
+def entropy_calc(item: Dict[Any, int], POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Reference and Response likelihood.
 
     :param item: number of positives in actual or predict vector per class (P or TOP)
-    :type item: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: Reference or Response likelihood as float
     """
     try:
         result = 0
@@ -558,23 +508,22 @@ def entropy_calc(item, POP):
         return "None"
 
 
-def weighted_kappa_calc(classes, table, P, TOP, POP, weight):
+def weighted_kappa_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        P: Dict[Any, int],
+        TOP: Dict[Any, int],
+        POP: Dict[Any, int],
+        weight: Dict[Any, Dict[Any, float]]) -> Union[float, str]:
     """
     Calculate Weighted kappa.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
     :param weight: weight matrix
-    :type weight: dict
-    :return: Weighted kappa as float
     """
     p_e = 0
     p_a = 0
@@ -591,13 +540,11 @@ def weighted_kappa_calc(classes, table, P, TOP, POP, weight):
         return "None"
 
 
-def kappa_no_prevalence_calc(overall_accuracy):
+def kappa_no_prevalence_calc(overall_accuracy: float) -> Union[float, str]:
     """
     Calculate Kappa no prevalence.
 
     :param overall_accuracy: overall accuracy
-    :type overall_accuracy: float
-    :return: Kappa no prevalence as float
     """
     try:
         result = 2 * overall_accuracy - 1
@@ -606,17 +553,13 @@ def kappa_no_prevalence_calc(overall_accuracy):
         return "None"
 
 
-def cross_entropy_calc(TOP, P, POP):
+def cross_entropy_calc(TOP: Dict[Any, int], P: Dict[Any, int], POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Cross entropy.
 
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: cross entropy as float
     """
     try:
         result = 0
@@ -631,17 +574,16 @@ def cross_entropy_calc(TOP, P, POP):
         return "None"
 
 
-def joint_entropy_calc(classes, table, POP):
+def joint_entropy_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Joint entropy.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: joint entropy as float
     """
     try:
         result = 0
@@ -655,19 +597,18 @@ def joint_entropy_calc(classes, table, POP):
         return "None"
 
 
-def conditional_entropy_calc(classes, table, P, POP):
+def conditional_entropy_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        P: Dict[Any, int],
+        POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Conditional entropy.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: conditional entropy as float
     """
     try:
         result = 0
@@ -685,15 +626,12 @@ def conditional_entropy_calc(classes, table, P, POP):
         return "None"
 
 
-def mutual_information_calc(response_entropy, conditional_entropy):
+def mutual_information_calc(response_entropy: float, conditional_entropy: float) -> Union[float, str]:
     """
     Calculate Mutual information.
 
     :param response_entropy: response entropy
-    :type response_entropy: float
     :param conditional_entropy: conditional entropy
-    :type conditional_entropy: float
-    :return: mutual information as float
     """
     try:
         return response_entropy - conditional_entropy
@@ -701,17 +639,13 @@ def mutual_information_calc(response_entropy, conditional_entropy):
         return "None"
 
 
-def kl_divergence_calc(P, TOP, POP):
+def kl_divergence_calc(P: Dict[Any, int], TOP: Dict[Any, int], POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Kullback-Liebler (KL) divergence.
 
     :param P: number of actual positives per class
-    :type P: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: KL divergence as float
     """
     try:
         result = 0
@@ -725,19 +659,14 @@ def kl_divergence_calc(P, TOP, POP):
         return "None"
 
 
-def lambda_B_calc(classes, table, TOP, POP):
+def lambda_B_calc(classes: List[Any], table: Dict[Any, Dict[Any, int]], TOP: Dict[Any, int], POP: int) -> Union[float, str]:
     """
     Calculate Goodman and Kruskal's lambda B.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: Goodman and Kruskal's lambda B as float
     """
     try:
         result = 0
@@ -751,19 +680,14 @@ def lambda_B_calc(classes, table, TOP, POP):
         return "None"
 
 
-def lambda_A_calc(classes, table, P, POP):
+def lambda_A_calc(classes: List[Any], table: Dict[Any, Dict[Any, int]], P: Dict[Any, int], POP: int) -> Union[float, str]:
     """
     Calculate Goodman and Kruskal's lambda A.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples
-    :type POP: int
-    :return: Goodman and Kruskal's lambda A as float
     """
     try:
         result = 0
@@ -780,21 +704,20 @@ def lambda_A_calc(classes, table, P, POP):
         return "None"
 
 
-def chi_square_calc(classes, table, TOP, P, POP):
+def chi_square_calc(
+        classes: List[Any],
+        table: Dict[Any, Dict[Any, int]],
+        TOP: Dict[Any, int],
+        P: Dict[Any, int],
+        POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Chi-squared.
 
     :param classes: confusion matrix classes
-    :type classes: list
     :param table: input confusion matrix
-    :type table: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param P: number of actual positives per class
-    :type P: dict
     :param POP: population or total number of samples per class
-    :type POP: dict
-    :return: chi-squared as float
     """
     try:
         result = 0
@@ -807,15 +730,12 @@ def chi_square_calc(classes, table, TOP, P, POP):
         return "None"
 
 
-def phi_square_calc(chi_square, POP):
+def phi_square_calc(chi_square: float, POP: int) -> Union[float, str]:
     """
     Calculate Phi-squared.
 
     :param chi_square: chi squared
-    :type chi_square: float
     :param POP: population or total number of samples
-    :type POP: int
-    :return: phi_squared as float
     """
     try:
         return chi_square / POP
@@ -823,15 +743,12 @@ def phi_square_calc(chi_square, POP):
         return "None"
 
 
-def cramers_V_calc(phi_square, classes):
+def cramers_V_calc(phi_square: float, classes: List[Any]) -> Union[float, str]:
     """
     Calculate Cramer's V.
 
     :param phi_square: phi_squared
-    :type phi_square: float
     :param classes: confusion matrix classes
-    :type classes: list
-    :return: Cramer's V as float
     """
     try:
         return math.sqrt((phi_square / (len(classes) - 1)))
@@ -839,13 +756,11 @@ def cramers_V_calc(phi_square, classes):
         return "None"
 
 
-def DF_calc(classes):
+def DF_calc(classes: List[Any]) -> Union[int, str]:
     """
     Calculate Chi-squared degree of freedom (DF).
 
     :param classes: confusion matrix classes
-    :type classes: list
-    :return: DF as int
     """
     try:
         return (len(classes) - 1)**2
@@ -853,15 +768,12 @@ def DF_calc(classes):
         return "None"
 
 
-def reliability_calc(RACC, ACC):
+def reliability_calc(RACC: float, ACC: float) -> Union[float, str]:
     """
     Calculate Reliability.
 
     :param RACC: random accuracy
-    :type RACC: float
     :param ACC: accuracy
-    :type ACC: float
-    :return: reliability as float
     """
     try:
         result = (ACC - RACC) / (1 - RACC)
@@ -870,7 +782,7 @@ def reliability_calc(RACC, ACC):
         return "None"
 
 
-def micro_calc(item1, item2):
+def micro_calc(item1: Dict[Any, int], item2: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate TPR, TNR, PPV, NPV, FNR, FPR, or F1 micro.
 
@@ -878,7 +790,6 @@ def micro_calc(item1, item2):
     :type item1:dict
     :param item2: item2 in micro averaging
     :type item2: dict
-    :return: PPV, NPV, TPR, TNR, FNR, FPR, or F1 micro as float
     """
     try:
         item1_sum = sum(item1.values())
@@ -888,13 +799,11 @@ def micro_calc(item1, item2):
         return "None"
 
 
-def macro_calc(item):
+def macro_calc(item: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate PPV_Macro, NPV_Macro, and TPR_Macro.
 
     :param item: True positive rate (TPR) or Positive predictive value (PPV)
-    :type item:dict
-    :return: PPV_Macro, NPV_Macro, or TPR_Macro as float
     """
     try:
         item_sum = sum(item.values())
@@ -904,17 +813,13 @@ def macro_calc(item):
         return "None"
 
 
-def PC_AC1_calc(P, TOP, POP):
+def PC_AC1_calc(P: Dict[Any, int], TOP: Dict[Any, int], POP: Dict[Any, int]) -> Union[float, str]:
     """
     Calculate Percent chance agreement for Gwet's AC1.
 
     :param P: number of actual positives per class
-    :type P: dict
     :param TOP: number of positives in predict vector per class
-    :type TOP: dict
     :param POP: population or total number of samples per class
-    :type POP:dict
-    :return: percent chance agreement as float
     """
     try:
         result = 0
@@ -928,13 +833,11 @@ def PC_AC1_calc(P, TOP, POP):
         return "None"
 
 
-def PC_S_calc(classes):
+def PC_S_calc(classes: List[Any]) -> Union[float, str]:
     """
     Calculate Percent chance agreement for Bennett-et-al.'s-S-score.
 
     :param classes: confusion matrix classes
-    :type classes: list
-    :return: percent chance agreement as float
     """
     try:
         return 1 / (len(classes))
@@ -942,13 +845,11 @@ def PC_S_calc(classes):
         return "None"
 
 
-def overall_jaccard_index_calc(jaccard_list):
+def overall_jaccard_index_calc(jaccard_list: List[float]) -> Union[Tuple[float, float], str]:
     """
     Calculate Overall Jaccard index.
 
     :param jaccard_list: list of Jaccard index for each class
-    :type jaccard_list: list
-    :return: (Jaccard_sum, Jaccard_mean) as tuple
     """
     try:
         jaccard_sum = sum(jaccard_list)
@@ -958,15 +859,12 @@ def overall_jaccard_index_calc(jaccard_list):
         return "None"
 
 
-def overall_accuracy_calc(TP, POP):
+def overall_accuracy_calc(TP: Dict[Any, int], POP: int) -> Union[float, str]:
     """
     Calculate Overall accuracy.
 
     :param TP: true positive
-    :type TP: dict
     :param POP: population or total number of samples
-    :type POP:int
-    :return: overall_accuracy as float
     """
     try:
         overall_accuracy = sum(TP.values()) / POP
@@ -975,13 +873,11 @@ def overall_accuracy_calc(TP, POP):
         return "None"
 
 
-def overall_random_accuracy_calc(item):
+def overall_random_accuracy_calc(item: Dict[Any, float]) -> Union[float, str]:
     """
     Calculate Overall random accuracy.
 
     :param item: random accuracy or random accuracy unbiased
-    :type item: dict
-    :return: overall random accuracy as float
     """
     try:
         return sum(item.values())
@@ -989,7 +885,7 @@ def overall_random_accuracy_calc(item):
         return "None"
 
 
-def overall_statistics(**kwargs):
+def overall_statistics(**kwargs: Dict[str, Any]) -> Dict[str, Union[float, Tuple[float, float], int, str]]:
     """
     Return Overall statistics.
 

--- a/pycm/overall_funcs.py
+++ b/pycm/overall_funcs.py
@@ -885,7 +885,7 @@ def overall_random_accuracy_calc(item: Dict[Any, float]) -> Union[float, str]:
         return "None"
 
 
-def overall_statistics(**kwargs: Dict[str, Any]) -> Dict[str, Union[float, Tuple[float, float], int, str]]:
+def overall_statistics(**kwargs: Any) -> Dict[str, Union[float, Tuple[float, float], int, str]]:
     """
     Return Overall statistics.
 

--- a/pycm/overall_funcs.py
+++ b/pycm/overall_funcs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Overall statistics functions."""
 from __future__ import division
-from typing import List, Dict, Tuple, Union, Any
+from typing import List, Dict, Tuple, Union, Any, Optional
 import math
 import operator as op
 from functools import reduce
@@ -15,8 +15,8 @@ def log_loss_calc(
         prob_vector: List[float],
         actual_vector: List[int],
         normalize: bool = True,
-        sample_weight: List[float] = None,
-        pos_class: Union[int, str] = None) -> Union[float, str]:
+        sample_weight: Optional[List[float]] = None,
+        pos_class: Optional[Union[int, str]] = None) -> Union[float, str]:
     """
     Calculate Log loss.
 
@@ -52,8 +52,8 @@ def brier_score_calc(
         classes: List[Any],
         prob_vector: List[float],
         actual_vector: List[int],
-        sample_weight: List[float] = None,
-        pos_class: Union[int, str] = None) -> Union[float, str]:
+        sample_weight: Optional[List[float]] = None,
+        pos_class: Optional[Union[int, str]] = None) -> Union[float, str]:
     """
     Calculate Brier score.
 

--- a/pycm/utils.py
+++ b/pycm/utils.py
@@ -253,17 +253,11 @@ def matrix_params_from_table(table: Dict[Any,
                                               int]],
                              classes: Optional[List[Any]] = None,
                              transpose: bool = False) -> Tuple[List[Any],
-                                                               Dict[Any,
-                                                                    Dict[Any,
-                                                                         int]],
-                                                               Dict[Any,
-                                                                    int],
-                                                               Dict[Any,
-                                                                    int],
-                                                               Dict[Any,
-                                                                    int],
-                                                               Dict[Any,
-                                                                    int]]:
+                                                               Dict[Any, Dict[Any, int]],
+                                                               Dict[Any, int],
+                                                               Dict[Any, int],
+                                                               Dict[Any, int],
+                                                               Dict[Any, int]]:
     """
     Calculate TP, TN, FP, and FN from the input confusion matrix and return them.
 


### PR DESCRIPTION
#### Reference Issues/PRs
#598 

#### What does this implement/fix? Explain your changes.
This PR adds type hints to the following files of the codebase and applies some additional fixes to files that have been changed in prior PRs:
- [x]  class_func,
- [x]  handlers,
- [x]  multi-labelcm,
- [x]  overall_funcs

#### Any other comments?
A final PR with `bash autopep8.bat` can make the format of hints more consistent (`X : TYP_A = DEFAULT` replaces `X : TYP_A=DEFAULT`)

