### PR TITLE
fix: respect digit precision in print_normalized_matrix

### DIFF
--- a/pycm/cm.py
+++ b/pycm/cm.py
@@ -166,7 +166,7 @@ class ConfusionMatrix():
                     classes, normalized_table)
             print(sparse_table_print(self.sparse_normalized_matrix))
         else:
-            print(table_print(classes, normalized_table))
+            print(table_print(classes, normalized_table, self.digit))
         if len(classes) >= CLASS_NUMBER_THRESHOLD:
             warn(CLASS_NUMBER_WARNING, RuntimeWarning)
 

--- a/pycm/output.py
+++ b/pycm/output.py
@@ -217,19 +217,26 @@ def pycm_help() -> None:
     print("Webpage : https://www.pycm.io")
 
 
-def table_print(classes: List[Any], table: Dict[str, Dict[str, int]]) -> str:
+def table_print(classes: List[Any], table: Dict[str, Dict[str, int]], digit: Optional[int] = None) -> str:
     """
     Return printable confusion matrix.
 
     :param classes: confusion matrix classes
     :param table: input confusion matrix
+    :param digit: number of decimal places for float values (default: None, use str())
     """
+    def fmt(v: Any) -> str:
+        """Format a cell value, rounding floats when digit is given."""
+        if digit is not None and isinstance(v, float):
+            return rounder(v, digit)
+        return str(v)
+
     classes_len = len(classes)
     table_list = []
     for key in classes:
         table_list.extend(list(table[key].values()))
     table_list.extend(classes)
-    table_max_length = max(map(len, map(str, table_list)))
+    table_max_length = max(map(len, map(fmt, table_list)))
     shift = "%-" + str(7 + table_max_length) + "s"
     result = shift % "Predict" + shift * \
         classes_len % tuple(map(str, classes)) + "\n"
@@ -237,7 +244,7 @@ def table_print(classes: List[Any], table: Dict[str, Dict[str, int]]) -> str:
     for key in classes:
         row = [table[key][i] for i in classes]
         result += shift % str(key) + \
-            shift * classes_len % tuple(map(str, row)) + "\n\n"
+            shift * classes_len % tuple(map(fmt, row)) + "\n\n"
     return result
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #430

#### What does this implement/fix?

`print_normalized_matrix()` ignores the `digit` parameter set on the `ConfusionMatrix` object — values are always displayed with 5 decimal places regardless of the requested precision.

**Before:**
```pycon
>>> cm = ConfusionMatrix(matrix={"Class1": {"Class1": 1, "Class2": 2}, "Class2": {"Class1": 0, "Class2": 5}}, digit=2)
>>> cm.print_normalized_matrix()
Predict       Class1        Class2
Actual
Class1        0.33333       0.66667

Class2        0.0           1.0
```

**After:**
```pycon
>>> cm = ConfusionMatrix(matrix={"Class1": {"Class1": 1, "Class2": 2}, "Class2": {"Class1": 0, "Class2": 5}}, digit=2)
>>> cm.print_normalized_matrix()
Predict      Class1       Class2
Actual
Class1       0.33         0.67

Class2       0.0          1.0
```

#### Changes

- `table_print()` gains an optional `digit` parameter; when provided, float cell values are formatted with `rounder(v, digit)` instead of `str(v)`.
- `print_normalized_matrix()` passes `self.digit` to `table_print()`.
- The raw integer matrix path (`print_matrix()`) is unaffected — integer values always use `str()`.
- All existing non-plot doctests pass.

This fix addresses the source-level correction that the maintainer requested when closing the earlier attempt in #431.

This pull request was prepared with the assistance of AI, under my direction and review.